### PR TITLE
fix Piece.verify method and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,7 @@ If `opts` is specified, then the default options (shown below) will be overridde
   peerId: String|Buffer, // Wire protocol peer ID (default=randomly generated)
   rtcConfig: Object,     // RTCPeerConnection configuration object (default=STUN only)
   storage: Function      // custom storage engine, or `false` to use in-memory engine
-  tracker: Boolean,      // Whether or not to enable trackers (default=true)
-  verify: Boolean        // Verify previously stored data before starting (default=false)
+  tracker: Boolean       // Whether or not to enable trackers (default=true)
 }
 ```
 
@@ -264,6 +263,15 @@ Start downloading a new torrent. Aliased as `client.download`.
 - parsed torrent (from [parse-torrent](https://github.com/feross/parse-torrent))
 - http/https url to a torrent file (string)
 - filesystem path to a torrent file (string)
+
+If `opts` is specified, then the default options (shown below) will be overridden.
+
+```js
+{
+  tmp: String,           // Custom folder where files will be downloaded (default=`/tmp/`)
+  verify: Boolean        // Verify previously stored data before starting (default=false)
+}
+```
 
 If `ontorrent` is specified, then it will be called when **this** torrent is ready to be
 used (i.e. metadata is available). Note: this is distinct from the 'torrent' event which

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -132,12 +132,14 @@ Piece.prototype.verify = function (buffer) {
     return
   }
 
+  var expected_hash
   if (self.noVerify) {
     self.verified = true
     onResult()
   } else {
     sha1(buffer, function (hash) {
       self.verified = (hash === self.hash)
+      expected_hash = hash
       onResult()
     })
   }
@@ -146,7 +148,7 @@ Piece.prototype.verify = function (buffer) {
     if (self.verified) {
       self.emit('done')
     } else {
-      self.emit('warning', new Error('piece ' + self.index + ' failed verification; ' + sha1(buffer) + ' expected ' + self.hash))
+      self.emit('warning', new Error('piece ' + self.index + ' failed verification; ' + expected_hash + ' expected ' + self.hash))
       self._reset()
     }
   }


### PR DESCRIPTION
Since sha1 is now async, this was failing with the following error:

```
.../node_modules/webtorrent/node_modules/simple-sha1/index.js:6
    cb(hash)
    ^
TypeError: undefined is not a function
    at .../node_modules/webtorrent/node_modules/simple-sha1/index.js:6:5
    at process._tickCallback (node.js:419:13)
```

I also updated the README to add some available options when adding a torrent.