### PR TITLE
Renamed video to media

### DIFF
--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -4,7 +4,7 @@ var debug = require('debug')('webtorrent:file-stream')
 var inherits = require('inherits')
 var path = require('path')
 var stream = require('stream')
-var VideoStream = require('./video-stream')
+var MediaStream = require('./media-stream')
 
 inherits(FileStream, stream.Readable)
 
@@ -108,8 +108,7 @@ FileStream.prototype.pipe = function (dst) {
         : self._extname === '.mp3'
           ? 'audio/mpeg'
           : undefined
-    // TODO: consider renaming VideoStream to MediaStream, since it supports audio as well.
-    return pipe.call(self, new VideoStream(dst, { type: type }))
+    return pipe.call(self, new MediaStream(dst, { type: type }))
   } else
     return pipe.call(self, dst)
 }

--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -101,13 +101,11 @@ FileStream.prototype.pipe = function (dst) {
 
   // <video> or <audio> tag
   if (dst && (dst.nodeName === 'VIDEO' || dst.nodeName === 'AUDIO')) {
-    var type = self._extname === '.webm'
-      ? 'video/webm; codecs="vorbis,vp8"'
-      : self._extname === '.mp4'
-        ? 'video/mp4; codecs="avc1.42c01e,mp4a.40.2"'
-        : self._extname === '.mp3'
-          ? 'audio/mpeg'
-          : undefined
+    var type = {
+      '.webm': 'video/webm; codecs="vorbis,vp8"',
+      '.mp4': 'video/mp4; codecs="avc1.42c01e,mp4a.40.2"',
+      '.mp3': 'audio/mpeg'
+    }[self._extname]
     return pipe.call(self, new MediaStream(dst, { type: type }))
   } else
     return pipe.call(self, dst)

--- a/lib/media-stream.js
+++ b/lib/media-stream.js
@@ -1,6 +1,6 @@
-module.exports = VideoStream
+module.exports = MediaStream
 
-var debug = require('debug')('webtorrent:video-stream')
+var debug = require('debug')('webtorrent:media-stream')
 var inherits = require('inherits')
 var once = require('once')
 var stream = require('stream')
@@ -8,25 +8,25 @@ var stream = require('stream')
 var MediaSource = typeof window !== 'undefined' &&
   (window.MediaSource || window.WebKitMediaSource)
 
-inherits(VideoStream, stream.Writable)
+inherits(MediaStream, stream.Writable)
 
-function VideoStream (video, opts) {
+function MediaStream (media, opts) {
   var self = this
-  if (!(self instanceof VideoStream)) return new VideoStream(video, opts)
+  if (!(self instanceof MediaStream)) return new MediaStream(media, opts)
   stream.Writable.call(self, opts)
 
-  self.video = video
+  self.media = media
   opts = opts || {}
   opts.type = opts.type || 'video/webm; codecs="vorbis,vp8"'
 
-  debug('new videostream %s %s', video, JSON.stringify(opts))
+  debug('new mediastream %s %s', media, JSON.stringify(opts))
 
   self._mediaSource = new MediaSource()
   self._playing = false
   self._sourceBuffer = null
   self._cb = null
 
-  self.video.src = window.URL.createObjectURL(self._mediaSource)
+  self.media.src = window.URL.createObjectURL(self._mediaSource)
 
   var sourceopen = once(function () {
     self._sourceBuffer = self._mediaSource.addSourceBuffer(opts.type)
@@ -43,7 +43,7 @@ function VideoStream (video, opts) {
   window.vs = self
 }
 
-VideoStream.prototype._write = function (chunk, encoding, cb) {
+MediaStream.prototype._write = function (chunk, encoding, cb) {
   var self = this
   if (!self._sourceBuffer) {
     self._cb = function (err) {
@@ -60,12 +60,12 @@ VideoStream.prototype._write = function (chunk, encoding, cb) {
   debug('appendBuffer %s', chunk.length)
   self._cb = cb
   if (!self._playing) {
-    self.video.play()
+    self.media.play()
     self._playing = true
   }
 }
 
-VideoStream.prototype._flow = function () {
+MediaStream.prototype._flow = function () {
   var self = this
   debug('flow')
   if (self._cb) {


### PR DESCRIPTION
Renamed instances of `video` to `media`. Left `window.vs` unchanged.
Switched the triple-ternary statement(s) into a map.