### PR TITLE
torrent: cancelBlocks on wire 'close'

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -514,6 +514,9 @@ Torrent.prototype._onWireWithMetadata = function (wire) {
 
   wire.on('close', function () {
     clearTimeout(timeoutId)
+    wire.requests.forEach(function (req) {
+      self.storage.cancelBlock(req.piece, req.offset)
+    })
   })
 
   wire.on('choke', function () {


### PR DESCRIPTION
We may need to add even more logic: malicious peers may hold back responses indefinitely. What do you think about request timeouts?

(Albeit not for malicious reasons, I once got no response from certain peers when choosing a wrong request size (> 16 KB)).