### PR TITLE
Display reserved blocks in CLI

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -452,12 +452,12 @@ function drawTorrent (torrent) {
     var pieces = torrent.storage.pieces
     for (var i = 0; i < pieces.length; i++) {
       var piece = pieces[i]
-      if (piece.verified || piece.blocksWritten === 0) {
+      if (piece.verified || (piece.blocksWritten === 0 && !piece.blocks[0])) {
         continue
       }
       var bar = ''
       for (var j = 0; j < piece.blocks.length; j++) {
-        bar += piece.blocks[j] ? '{green:█}' : '{red:█}'
+        bar += piece.blocks[j] ? (piece.blocks[j] === 1 ? '{blue:█}' : '{green:█}') : '{red:█}'
       }
       clivas.line('{4+cyan:' + i + '} ' + bar)
       linesremaining -= 1


### PR DESCRIPTION
Green blocks in CLI cmd.js represent non-BLOCK_BLANK blocks, which includes reserved blocks. 

More info https://github.com/feross/webtorrent/issues/266 

This patch add blue marks for reserved blocks