### PR TITLE
Allow to cancel reserve on unwritten blocks

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -104,7 +104,7 @@ Piece.prototype.reserveBlock = function (endGame) {
 
 Piece.prototype.cancelBlock = function (offset) {
   var self = this
-  if (!self.buffer || !self._verifyOffset(offset)) {
+  if (!self._verifyOffset(offset)) {
     return false
   }
 


### PR DESCRIPTION
Trying to figure out why https://github.com/feross/webtorrent/issues/266 happens and after debugging using the https://github.com/feross/webtorrent/pull/267 PR, it seems like the cancelBlock is called as you mention here https://github.com/feross/webtorrent/pull/253 but if the **block is the first in the piece** and was never written, the 'reserve'  is never really canceled because the buffer is null (because is lazy initialized)
