### PR TITLE
adhere to padded-blocks

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -254,7 +254,6 @@ function runCreate (input) {
 var client, href, playerName, server, serving
 
 function runDownload (torrentId) {
-
   if (!argv.out && !argv.stdout && !playerName) {
     argv.out = process.cwd()
   }

--- a/index.js
+++ b/index.js
@@ -169,7 +169,6 @@ WebTorrent.prototype.download = function (torrentId, opts, ontorrent) {
   if (torrent) {
     if (torrent.ready) process.nextTick(_ontorrent)
     else torrent.on('ready', _ontorrent)
-
   } else {
     torrent = new Torrent(torrentId, opts)
     self.torrents.push(torrent)

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -529,7 +529,6 @@ Torrent.prototype._onWire = function (wire, addr) {
 
   // If peer supports DHT, send PORT message to report DHT listening port
   if (wire.peerExtensions.dht && self.client.dht && self.client.dht.listening) {
-
     // When peer sends PORT, add them to the routing table
     wire.on('port', function (port) {
       if (!wire.remoteAddress) {


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.