### PR TITLE
Always pass 'elem' to 'append-to' callback

### DIFF
--- a/lib/append-to.js
+++ b/lib/append-to.js
@@ -136,7 +136,7 @@ module.exports = function appendTo (file, rootElem, cb) {
       elem.src = url
       elem.alt = file.name
       rootElem.appendChild(elem)
-      cb(null)
+      cb(null, elem)
     })
   }
 
@@ -147,7 +147,7 @@ module.exports = function appendTo (file, rootElem, cb) {
       elem.src = url
       if (extname !== '.pdf') elem.sandbox = 'allow-forms allow-scripts'
       rootElem.appendChild(elem)
-      cb(null)
+      cb(null, elem)
     })
   }
 


### PR DESCRIPTION
Looks like it was forgotten for 'img' and 'iframe'.