### PR TITLE
Add an 'announce' option to announce to custom trackers

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -43,6 +43,7 @@ var argv = minimist(process.argv.slice(2), {
     s: 'select',
     i: 'index',
     o: 'out',
+    a: 'announce',
     q: 'quiet',
     h: 'help',
     v: 'version'
@@ -63,6 +64,7 @@ var argv = minimist(process.argv.slice(2), {
   ],
   string: [ // options that are always strings
     'out',
+    'announce',
     'blocklist',
     'subtitles',
     'on-done',
@@ -201,6 +203,7 @@ Options (advanced):
     -p, --port [number]     change the http server port [default: 8000]
     -t, --subtitles [path]  load subtitles file
     -b, --blocklist [path]  load blocklist file/http url
+    -a, --announce [url]    tracker URL to announce to
     -q, --quiet             don't show UI on stdout
     --on-done [script]      run script after torrent download is done
     --on-exit [script]      run script before program exit
@@ -459,7 +462,7 @@ function runSeed (input) {
   })
   .on('error', fatalError)
 
-  client.seed(input)
+  client.seed(input, { announce: argv.announce })
 
   client.on('torrent', function (torrent) {
     if (argv.quiet) console.log(torrent.magnetURI)


### PR DESCRIPTION
```sh
webtorrent seed somefile -a http://localhost:8000/announce -a udp://localhost:8000 -q
```

Output:

```
magnet:?xt=urn:btih:066ed351804835cf0fec21e3b352f58e270a26d5&dn=somefile&tr=http%3A%2F%2Flocalhost%3A8000%2Fannounce&tr=udp%3A%2F%2Flocalhost%3A8000
```