### PR TITLE
VerifyPieces: Removed Parallel execution to prevent excessive memory consumption...

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -80,7 +80,7 @@ function Torrent (torrentId, opts) {
   self.numBlockedPeers = 0
   self.files = null
   self.done = false
-  self.verifyingPieces = false;
+  self.verifyingPieces = false
 
   self._amInterested = false
   self._selections = []
@@ -358,9 +358,8 @@ Torrent.prototype._onMetadata = function (metadata) {
 
     self._onWireWithMetadata(wire)
   })
-    
-  
-  //verify pieces
+
+  // Verify pieces
   var verifyPiece = function (index) {
     self.store.get(index, function (err, buf) {
       if (!err) {
@@ -372,23 +371,22 @@ Torrent.prototype._onMetadata = function (metadata) {
             self._reservations[index] = null
             self.bitfield.set(index, true)
           } else {
-             debug('piece invalid %s', index)
+            debug('piece invalid %s', index)
           }
         })
       }
-      //Verify next piece?
+      // Verify next piece?
       if (index + 1 < self.pieces.length) {
-        setImmediate(function () { verifyPiece(index + 1) });
-      }
-      else {
-        self.verifyingPieces = false;
+        setImmediate(function () { verifyPiece(index + 1) })
+      } else {
+        self.verifyingPieces = false
         debug('done verifying')
       }
     })
   }
   debug('verifying existing torrent data')
-  self.verifyingPieces = true;
-  verifyPiece(0);
+  self.verifyingPieces = true
+  verifyPiece(0)
 
   self.emit('metadata')
   self._onStore()

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -80,6 +80,7 @@ function Torrent (torrentId, opts) {
   self.numBlockedPeers = 0
   self.files = null
   self.done = false
+  self.verifyingPieces = false;
 
   self._amInterested = false
   self._selections = []
@@ -357,12 +358,12 @@ Torrent.prototype._onMetadata = function (metadata) {
 
     self._onWireWithMetadata(wire)
   })
-
-  debug('verifying existing torrent data')
-  parallel(self.pieces.map(function (piece, index) {
-    return function (cb) {
-      self.store.get(index, function (err, buf) {
-        if (err) return cb(null) // ignore error
+    
+  
+  //verify pieces
+  var verifyPiece = function (index) {
+    self.store.get(index, function (err, buf) {
+      if (!err) {
         sha1(buf, function (hash) {
           if (hash === self._hashes[index]) {
             if (!self.pieces[index]) return
@@ -371,19 +372,26 @@ Torrent.prototype._onMetadata = function (metadata) {
             self._reservations[index] = null
             self.bitfield.set(index, true)
           } else {
-            debug('piece invalid %s', index)
+             debug('piece invalid %s', index)
           }
-          cb(null)
         })
-      })
-    }
-  }), function (err) {
-    if (err) return self._onError(err)
-    debug('done verifying')
-    self._onStore()
-  })
+      }
+      //Verify next piece?
+      if (index + 1 < self.pieces.length) {
+        setImmediate(function () { verifyPiece(index + 1) });
+      }
+      else {
+        self.verifyingPieces = false;
+        debug('done verifying')
+      }
+    })
+  }
+  debug('verifying existing torrent data')
+  self.verifyingPieces = true;
+  verifyPiece(0);
 
   self.emit('metadata')
+  self._onStore()
 }
 
 /**


### PR DESCRIPTION
…and also to prevent UI/Process to hang when verifying large files.

Also introduced a **verifyingPieces** flag on Torrent - in order to let consumers of the library detect when files are being verified.
self._onStore() is now being invoked before Torrent is verified - so that consumers can poll on the verifyingPieces flag.

UI Demo: http://screencast.com/t/NgbUPvQLik1O