### PR TITLE
exec/spawn cmd.js with 'node'

### DIFF
--- a/test/basic-node.js
+++ b/test/basic-node.js
@@ -1,16 +1,17 @@
 var WebTorrent = require('../')
 var fs = require('fs')
 var http = require('http')
+var path = require('path')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 
-var leavesPath = __dirname + '/torrents/leaves.torrent'
+var leavesPath = path.resolve(__dirname, 'torrents', 'leaves.torrent')
 var leaves = fs.readFileSync(leavesPath)
 var leavesTorrent = parseTorrent(leaves)
-var leavesBookPath = __dirname + '/content/Leaves of Grass by Walt Whitman.epub'
+var leavesBookPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 var leavesMagnetURI = 'magnet:?xt=urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36&dn=Leaves+of+Grass+by+Walt+Whitman.epub&tr=http%3A%2F%2Ftracker.bittorrent.am%2Fannounce&tr=http%3A%2F%2Ftracker.thepiratebay.org%2Fannounce&tr=udp%3A%2F%2Ffr33domtracker.h33t.com%3A3310%2Fannounce&tr=udp%3A%2F%2Ftracker.ccc.de%3A80&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80'
-var numbersPath = __dirname + '/content/numbers'
-var folderPath = __dirname + '/content/folder'
+var numbersPath = path.resolve(__dirname, 'content', 'numbers')
+var folderPath = path.resolve(__dirname, 'content', 'folder')
 
 test('client.add: http url to a torrent file, string', function (t) {
   t.plan(3)

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,12 +1,13 @@
+var path = require('path')
 var fs = require('fs')
 var extend = require('xtend')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var leaves = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leaves = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesTorrent = parseTorrent(leaves)
-var leavesBook = fs.readFileSync(__dirname + '/content/Leaves of Grass by Walt Whitman.epub')
+var leavesBook = fs.readFileSync(path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub'))
 
 var leavesMagnetURI = 'magnet:?xt=urn:btih:d2474e86c95b19b8bcfdb92bc12c9d44667cfa36&dn=Leaves+of+Grass+by+Walt+Whitman.epub&tr=http%3A%2F%2Ftracker.bittorrent.am%2Fannounce&tr=http%3A%2F%2Ftracker.thepiratebay.org%2Fannounce&tr=udp%3A%2F%2Ffr33domtracker.h33t.com%3A3310%2Fannounce&tr=udp%3A%2F%2Ftracker.ccc.de%3A80&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80'
 

--- a/test/blocklist-dht.js
+++ b/test/blocklist-dht.js
@@ -1,12 +1,13 @@
 var auto = require('run-auto')
 var DHT = require('bittorrent-dht/server')
+var path = require('path')
 var fs = require('fs')
 var networkAddress = require('network-address')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 // remove trackers from .torrent file

--- a/test/blocklist-tracker.js
+++ b/test/blocklist-tracker.js
@@ -1,11 +1,12 @@
 var auto = require('run-auto')
+var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var TrackerServer = require('bittorrent-tracker/server')
 var WebTorrent = require('../')
 
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 test('blocklist blocks peers discovered via tracker', function (t) {

--- a/test/blocklist.js
+++ b/test/blocklist.js
@@ -1,3 +1,4 @@
+var path = require('path')
 var fs = require('fs')
 var http = require('http')
 var parseTorrent = require('parse-torrent')
@@ -5,10 +6,10 @@ var test = require('tape')
 var WebTorrent = require('../')
 var zlib = require('zlib')
 
-var blocklistPath = __dirname + '/content/blocklist.txt'
-var blocklistGzipPath = __dirname + '/content/blocklist.txt.gz'
+var blocklistPath = path.resolve(__dirname, 'content', 'blocklist.txt')
+var blocklistGzipPath = path.resolve(__dirname, 'content', 'blocklist.txt.gz')
 
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 // remove trackers from .torrent file

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,9 +1,10 @@
 var cp = require('child_process')
+var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 
-var CMD = __dirname + '/../bin/cmd.js'
+var CMD = path.resolve(__dirname, '..', 'bin', 'cmd.js')
 
 test('Command line: webtorrent help', function (t) {
   t.plan(6)
@@ -26,7 +27,7 @@ test('Command line: webtorrent help', function (t) {
 
 test('Command line: webtorrent version', function (t) {
   t.plan(6)
-  var expectedVersion = require(__dirname + '/../package.json').version + '\n'
+  var expectedVersion = require(path.resolve(__dirname, '..', 'package.json')).version + '\n'
 
   cp.exec(CMD + ' version', function (err, data) {
     t.error(err)
@@ -47,7 +48,7 @@ test('Command line: webtorrent version', function (t) {
 test('Command line: webtorrent info /path/to/file.torrent', function (t) {
   t.plan(3)
 
-  var leavesPath = __dirname + '/torrents/leaves.torrent'
+  var leavesPath = path.resolve(__dirname, 'torrents', 'leaves.torrent')
   var leaves = fs.readFileSync(leavesPath)
 
   cp.exec(CMD + ' info ' + leavesPath, function (err, data) {
@@ -80,7 +81,7 @@ test('Command line: webtorrent info magnet_uri', function (t) {
 test('Command line: webtorrent create /path/to/file', function (t) {
   t.plan(1)
 
-  var leavesPath = __dirname + '/content/Leaves of Grass by Walt Whitman.epub'
+  var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 
   var child = cp.spawn(CMD, [ 'create', leavesPath ])
   child.on('error', function (err) { t.fail(err) })

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -4,7 +4,8 @@ var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 
-var CMD = path.resolve(__dirname, '..', 'bin', 'cmd.js')
+var CMD_PATH = path.resolve(__dirname, '..', 'bin', 'cmd.js')
+var CMD = 'node ' + CMD_PATH
 
 test('Command line: webtorrent help', function (t) {
   t.plan(6)
@@ -83,7 +84,7 @@ test('Command line: webtorrent create /path/to/file', function (t) {
 
   var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 
-  var child = cp.spawn(CMD, [ 'create', leavesPath ])
+  var child = cp.spawn('node', [ CMD_PATH, 'create', leavesPath ])
   child.on('error', function (err) { t.fail(err) })
 
   var chunks = []

--- a/test/download-dht-magnet.js
+++ b/test/download-dht-magnet.js
@@ -1,13 +1,14 @@
 var auto = require('run-auto')
 var DHT = require('bittorrent-dht/server')
+var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var leavesPath = __dirname + '/content/Leaves of Grass by Walt Whitman.epub'
+var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 var leavesFile = fs.readFileSync(leavesPath)
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 // remove trackers from .torrent file

--- a/test/download-dht-torrent.js
+++ b/test/download-dht-torrent.js
@@ -1,13 +1,14 @@
 var auto = require('run-auto')
 var DHT = require('bittorrent-dht/server')
+var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var leavesPath = __dirname + '/content/Leaves of Grass by Walt Whitman.epub'
+var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 var leavesFile = fs.readFileSync(leavesPath)
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 // remove trackers from .torrent file

--- a/test/download-private-dht.js
+++ b/test/download-private-dht.js
@@ -1,14 +1,15 @@
 var auto = require('run-auto')
 var DHT = require('bittorrent-dht/server')
+var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var bunnyTorrent = fs.readFileSync(__dirname + '/torrents/big-buck-bunny-private.torrent')
+var bunnyTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'big-buck-bunny-private.torrent'))
 var bunnyParsed = parseTorrent(bunnyTorrent)
 
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 // remove trackers from .torrent file

--- a/test/download-tracker-magnet.js
+++ b/test/download-tracker-magnet.js
@@ -1,13 +1,14 @@
 var auto = require('run-auto')
+var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var TrackerServer = require('bittorrent-tracker/server')
 var WebTorrent = require('../')
 
-var leavesPath = __dirname + '/content/Leaves of Grass by Walt Whitman.epub'
+var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 var leavesFile = fs.readFileSync(leavesPath)
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 test('Download using UDP tracker (via magnet uri)', function (t) {

--- a/test/download-tracker-torrent.js
+++ b/test/download-tracker-torrent.js
@@ -1,13 +1,14 @@
 var auto = require('run-auto')
+var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var TrackerServer = require('bittorrent-tracker/server')
 var WebTorrent = require('../')
 
-var leavesPath = __dirname + '/content/Leaves of Grass by Walt Whitman.epub'
+var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 var leavesFile = fs.readFileSync(leavesPath)
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 test('Download using UDP tracker (via .torrent file)', function (t) {

--- a/test/download-webseed-magnet.js
+++ b/test/download-webseed-magnet.js
@@ -8,10 +8,10 @@ var serveStatic = require('serve-static')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var leavesPath = __dirname + '/content/Leaves of Grass by Walt Whitman.epub'
+var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 var leavesFilename = 'Leaves of Grass by Walt Whitman.epub'
 var leavesFile = fs.readFileSync(leavesPath)
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 // remove trackers from .torrent file

--- a/test/download-webseed-torrent.js
+++ b/test/download-webseed-torrent.js
@@ -9,10 +9,10 @@ var serveStatic = require('serve-static')
 var finalhandler = require('finalhandler')
 var path = require('path')
 
-var leavesPath = __dirname + '/content/Leaves of Grass by Walt Whitman.epub'
+var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 var leavesFilename = 'Leaves of Grass by Walt Whitman.epub'
 var leavesFile = fs.readFileSync(leavesPath)
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesParsed = parseTorrent(leavesTorrent)
 
 // remove trackers from .torrent file

--- a/test/duplicates.js
+++ b/test/duplicates.js
@@ -1,8 +1,9 @@
+var path = require('path')
 var fs = require('fs')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var leavesBook = fs.readFileSync(__dirname + '/content/Leaves of Grass by Walt Whitman.epub')
+var leavesBook = fs.readFileSync(path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub'))
 
 test('client.seed followed by duplicate client.add', function (t) {
   t.plan(3)

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -1,9 +1,10 @@
+var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var leaves = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leaves = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesTorrent = parseTorrent(leaves)
 
 test('extension support', function (t) {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -1,9 +1,10 @@
+var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var leaves = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leaves = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 var leavesTorrent = parseTorrent(leaves)
 
 test('ut_metadata transfer', function (t) {

--- a/test/multiple.js
+++ b/test/multiple.js
@@ -1,10 +1,11 @@
 /*
+var path = require('path')
 var fs = require('fs')
 var test = require('tape')
 var WebTorrent = require('../')
 
 var torrents = [ 'leaves', 'pride' ].map(function (name) {
-  return fs.readFileSync(__dirname + '/torrents/' + name + '.torrent')
+  return fs.readFileSync(path.resolve(__dirname, 'torrents', name + '.torrent'))
 })
 
 // TODO: replace this with a test that can run offline

--- a/test/server.js
+++ b/test/server.js
@@ -1,10 +1,11 @@
+var path = require('path')
 var fs = require('fs')
 var get = require('simple-get')
 var test = require('tape')
 var WebTorrent = require('../')
 
-var leavesPath = __dirname + '/content/Leaves of Grass by Walt Whitman.epub'
-var leavesTorrent = fs.readFileSync(__dirname + '/torrents/leaves.torrent')
+var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
+var leavesTorrent = fs.readFileSync(path.resolve(__dirname, 'torrents', 'leaves.torrent'))
 
 test('start http server programmatically', function (t) {
   t.plan(4)


### PR DESCRIPTION
See https://github.com/feross/webtorrent/issues/429#issuecomment-139878312

> This is because a windows system doesn't use the shebang so it might
> not know how to execute a js file. Spawning using node and node will
> understand how to read this.

(includes and resolves #449)