### PR TITLE
travis: cache node_modules for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ env:
   global:
   - secure: AJsEWFnWC5W8hcF3hJzm3PT7heazJpKg85xiSvIWVzLHZU/s0h4+WfJ6t0F9v3L4awaowm62vy8CRaxRkB4lJyJg+JK2K0QN7lNFGj2f8Jx2cFlVJ1IyY959GY4iUg66JrNj1yzS02+yQfweDngyifqzb7IlxnowiveDjUO2gyo=
   - secure: hvihwLUqlPchrGFXKWFF7iKRugISU7r/gLBo6O63nPeg0OwnYqYcC2BnBWoSiOdu9oR5bM4a5u0os04XL+bP3dqt324g0uBTqvyyxD6NhBsphVFkUmdUH3HMe7IQY6JTns96KT/6UkQapKhIuW4CUDeidR+5NFKvyRdKIjSawS4=
+cache:
+  directories:
+  - node_modules


### PR DESCRIPTION
This makes builds around 90 seconds faster. See here for an example: https://travis-ci.org/joseph-onsip/webtorrent/builds/83604415

![This command finished after 5.75 seconds.](https://cloud.githubusercontent.com/assets/6473925/10270448/b8b3ac80-6abf-11e5-9b30-8057740989be.png)

http://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/