### PR TITLE
Accommodate Chrome/FF optional Blob arg difference

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -114,7 +114,7 @@ File.prototype.getBlobURL = function (cb) {
     if (err) return cb(err)
     var ext = path.extname(self.name).toLowerCase()
     var type = mime[ext]
-    var blob = new window.Blob([ buffer ], type && { type: type })
+    var blob = type ? new window.Blob([ buffer ], { type: type }) : new window.Blob([ buffer ])
     var url = window.URL.createObjectURL(blob)
     cb(null, url)
   })


### PR DESCRIPTION
The [specs](http://www.w3.org/TR/FileAPI/#constructorParams) say that the second Blob constructor argument is optional, however Chrome and FF implement that differently. FF checks if the second arg is not `undefined`, while Chrome checks `arguments.length`.

As a result, if the second argument is `undefined`, Chrome will [throw an error](https://chromium.googlesource.com/chromium/blink/+/72fef91ac1ef679207f51def8133b336a6f6588f/LayoutTests/fast/files/blob-constructor.html#55), while FF will just ignore it.

This change makes it so that the second arg is not passed at all when it's undefined, and Chrome is happy as a result.