### PR TITLE
tests use cross-spawn-async instead of child_process.spawn

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt text eol=lf

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-var cp = require('child_process')
+var spawn = require('cross-spawn-async')
 
 var runBrowserTests = !process.env.TRAVIS_PULL_REQUEST ||
   process.env.TRAVIS_PULL_REQUEST === 'false'
 
-var node = cp.spawn('npm', ['run', 'test-node'], { stdio: 'inherit' })
+var node = spawn('npm', ['run', 'test-node'], { stdio: 'inherit' })
 node.on('close', function (code) {
   if (code === 0 && runBrowserTests) {
-    var browser = cp.spawn('npm', ['run', 'test-browser'], { stdio: 'inherit' })
+    var browser = spawn('npm', ['run', 'test-browser'], { stdio: 'inherit' })
     browser.on('close', function (code) {
       process.exit(code)
     })

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chunk-store-stream": "^2.0.0",
     "clivas": "^0.2.0",
     "create-torrent": "^3.4.0",
+    "cross-spawn-async": "^2.0.0",
     "debug": "^2.1.0",
     "end-of-stream": "^1.0.0",
     "executable": "^1.1.0",

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1,4 +1,5 @@
 var cp = require('child_process')
+var spawn = require('cross-spawn-async')
 var path = require('path')
 var fs = require('fs')
 var parseTorrent = require('parse-torrent')
@@ -84,7 +85,7 @@ test('Command line: webtorrent create /path/to/file', function (t) {
 
   var leavesPath = path.resolve(__dirname, 'content', 'Leaves of Grass by Walt Whitman.epub')
 
-  var child = cp.spawn('node', [ CMD_PATH, 'create', leavesPath ])
+  var child = spawn('node', [ CMD_PATH, 'create', leavesPath ])
   child.on('error', function (err) { t.fail(err) })
 
   var chunks = []


### PR DESCRIPTION
This allows Windows to run the tests, as promised in
https://github.com/feross/webtorrent/issues/429#issuecomment-146061289

Note that there are a couple of outstanding failures on Windows:

    # client.seed: filesystem path to folder with one file, string
    not ok 8 should be equal
      ---
        operator: equal
        expected: '3a686c32404af0a66913dd5f8d2b40673f8d4490'
        actual:   'e6887b78d89d995876c7cef3476b6fb32c4c4e3d'
      ...
    not ok 9 should be equal
      ---
        operator: equal
        expected: |-
          'magnet:?xt=urn:btih:3a686c32404af0a66913dd5f8d2b40673f8d4490&dn=folder&tr=udp%3A%2F%2Ftracker.webtorrent.io%3A80'
        actual: |-
          'magnet:?xt=urn:btih:e6887b78d89d995876c7cef3476b6fb32c4c4e3d&dn=folder&tr=udp%3A%2F%2Ftracker.webtorrent.io%3A80'