### PR TITLE
clone.sh should use bash due to bashisms

### DIFF
--- a/bin/clone.sh
+++ b/bin/clone.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$#" -ne 1 ] || ! [ -d "$1" ]; then
   echo "Usage: $0 DIRECTORY_TO_CLONE_INTO" >&2


### PR DESCRIPTION
Bashisms pushd/popd don't work so well if /bin/sh is dash, as is the case on a Debian machine.