### PR TITLE
timeRemaining should be 0 once done (Fix #503)

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -94,6 +94,7 @@ function Torrent (torrentId, opts) {
 // Time remaining (in milliseconds)
 Object.defineProperty(Torrent.prototype, 'timeRemaining', {
   get: function () {
+    if (this.done) return 0
     if (this.swarm.downloadSpeed() === 0) return Infinity
     else return ((this.length - this.downloaded) / this.swarm.downloadSpeed()) * 1000
   }


### PR DESCRIPTION
timeRemaining property should be 0 once a torrent has been downloaded (or is being seeded)