### PR TITLE
Initialize pieces on constructor

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -81,8 +81,9 @@ function Torrent (torrentId, opts) {
   this.numBlockedPeers = 0
   this.files = null
   this.done = false
-
+  
   this._amInterested = false
+  this.pieces = []
   this._selections = []
   this._critical = []
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -81,7 +81,7 @@ function Torrent (torrentId, opts) {
   this.numBlockedPeers = 0
   this.files = null
   this.done = false
-  
+
   this._amInterested = false
   this.pieces = []
   this._selections = []


### PR DESCRIPTION
Many prototype functions and properties use it and if it hasn't been initialized it will throw error as it's undefined.