### PR TITLE
Fix timeRemaining issue

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -97,7 +97,7 @@ function Torrent (torrentId, opts) {
 Object.defineProperty(Torrent.prototype, 'timeRemaining', {
   get: function () {
     if (this.done) return 0
-    if (this.swarm.downloadSpeed() === 0) return Infinity
+    if (this.swarm === undefined || this.swarm.downloadSpeed() === 0) return Infinity
     else return ((this.length - this.downloaded) / this.swarm.downloadSpeed()) * 1000
   }
 })


### PR DESCRIPTION
When the swarm hasn't been created but the timeRemaining property is accessed, it causes an error.