### PR TITLE
File select with priority - fixes #550

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -44,9 +44,9 @@ function File (torrent, file) {
  * Selects the file to be downloaded, but at a lower priority than files with streams.
  * Useful if you know you need the file at a later stage.
  */
-File.prototype.select = function () {
+File.prototype.select = function (priority) {
   if (this.length === 0) return
-  this._torrent.select(this._startPiece, this._endPiece, false)
+  this._torrent.select(this._startPiece, this._endPiece, priority)
 }
 
 /**


### PR DESCRIPTION
Allows selecting with a set priority, if not passed as argument, it will default to false/0