### PR TITLE
Fix downloaded property access

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -105,6 +105,7 @@ Object.defineProperty(Torrent.prototype, 'timeRemaining', {
 // Bytes completed (excluding invalid data)
 Object.defineProperty(Torrent.prototype, 'downloaded', {
   get: function () {
+    if (!this.bitfield) return 0
     var downloaded = 0
     for (var index = 0, len = this.pieces.length; index < len; ++index) {
       if (this.bitfield.get(index)) { // verified data


### PR DESCRIPTION
When bitfield is not yet created, accessing downloaded property will throw an error.