### PR TITLE
Chromecast torrent title

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -454,7 +454,9 @@ function runDownload (torrentId) {
     if (argv.chromecast) {
       var chromecasts = require('chromecasts')()
       chromecasts.on('update', function (player) {
-        player.play(href)
+          player.play(href, {
+              title: torrent.name
+          })
       })
     }
 


### PR DESCRIPTION
Attach the torrent name so chromecast shows the name of the torrent file on the preload screen.