### PR TITLE
Add appveyor.yml for automated Windows testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+# Explicitly ensure line endings aren't mangled
+# http://www.appveyor.com/docs/lang/nodejs-iojs#line-endings
+init:
+  - git config --global core.autocrlf input
+
+# Test against these versions of Node.js
+# https://www.appveyor.com/docs/lang/nodejs-iojs#testing-under-multiple-versions-of-node-js-or-io-js
+environment:
+  matrix:
+  - nodejs_version: "" # https://www.appveyor.com/docs/installed-software#node-js
+  - nodejs_version: "4"
+  - nodejs_version: "0.12"
+
+# http://www.appveyor.com/docs/build-cache
+cache:
+  - node_modules
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm run test-node # (not `npm test` because saucelabs credentials are missing)
+
+# Don't actually build.
+# https://www.appveyor.com/docs/lang/nodejs-iojs#quick-start
+build: off


### PR DESCRIPTION
https://github.com/feross/webtorrent/issues/429 reminded me that webtorrent doesn't have any automated Windows testing. [AppVeyor](http://www.appveyor.com/) is a service that can provide that for us. Here's an example build: https://ci.appveyor.com/project/josephfrazier/webtorrent/build/1.0.6

Note that simply merging this isn't quite enough to get builds running. AppVeyor also needs to be configured [here](https://ci.appveyor.com/projects/new). I should be able to do this if/once this is merged.