### PR TITLE
Use Electron to run browser tests with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ env:
   global:
   - secure: AJsEWFnWC5W8hcF3hJzm3PT7heazJpKg85xiSvIWVzLHZU/s0h4+WfJ6t0F9v3L4awaowm62vy8CRaxRkB4lJyJg+JK2K0QN7lNFGj2f8Jx2cFlVJ1IyY959GY4iUg66JrNj1yzS02+yQfweDngyifqzb7IlxnowiveDjUO2gyo=
   - secure: hvihwLUqlPchrGFXKWFF7iKRugISU7r/gLBo6O63nPeg0OwnYqYcC2BnBWoSiOdu9oR5bM4a5u0os04XL+bP3dqt324g0uBTqvyyxD6NhBsphVFkUmdUH3HMe7IQY6JTns96KT/6UkQapKhIuW4CUDeidR+5NFKvyRdKIjSawS4=
+# Get Electron working
+# https://github.com/atom/electron/issues/4194#issuecomment-173925019
+before_script:
+  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start

--- a/bin/test.js
+++ b/bin/test.js
@@ -5,14 +5,17 @@ var spawn = require('cross-spawn-async')
 var runBrowserTests = process.env.TRAVIS && (!process.env.TRAVIS_PULL_REQUEST ||
   process.env.TRAVIS_PULL_REQUEST === 'false')
 
-var node = spawn('npm', ['run', 'test-node'], { stdio: 'inherit' })
-node.on('close', function (code) {
-  if (code === 0 && runBrowserTests) {
-    var browser = spawn('npm', ['run', 'test-browser'], { stdio: 'inherit' })
-    browser.on('close', function (code) {
+npmRun('test-node', function (code) {
+  if (code === 0) {
+    var scriptName = runBrowserTests ? 'test-browser' : 'test-browser-headless'
+    npmRun(scriptName, function (code) {
       process.exit(code)
     })
   } else {
     process.exit(code)
   }
 })
+
+function npmRun (scriptName, onClose) {
+  spawn('npm', ['run', scriptName], { stdio: 'inherit' }).on('close', onClose)
+}

--- a/bin/test.js
+++ b/bin/test.js
@@ -2,12 +2,11 @@
 
 var spawn = require('cross-spawn-async')
 
-var runBrowserTests = process.env.TRAVIS && (!process.env.TRAVIS_PULL_REQUEST ||
-  process.env.TRAVIS_PULL_REQUEST === 'false')
+var runSauceLabs = process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY
 
 npmRun('test-node', function (code) {
   if (code === 0) {
-    var scriptName = runBrowserTests ? 'test-browser' : 'test-browser-headless'
+    var scriptName = runSauceLabs ? 'test-browser' : 'test-browser-headless'
     npmRun(scriptName, function (code) {
       process.exit(code)
     })

--- a/bin/test.js
+++ b/bin/test.js
@@ -2,8 +2,8 @@
 
 var spawn = require('cross-spawn-async')
 
-var runBrowserTests = !process.env.TRAVIS_PULL_REQUEST ||
-  process.env.TRAVIS_PULL_REQUEST === 'false'
+var runBrowserTests = process.env.TRAVIS && (!process.env.TRAVIS_PULL_REQUEST ||
+  process.env.TRAVIS_PULL_REQUEST === 'false')
 
 var node = spawn('npm', ['run', 'test-node'], { stdio: 'inherit' })
 node.on('close', function (code) {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "brfs": "^1.2.0",
     "browserify": "^13.0.0",
     "cross-spawn-async": "^2.0.0",
+    "electron-prebuilt": "^0.36.7",
     "finalhandler": "^0.4.0",
     "run-series": "^1.0.2",
     "serve-static": "^1.9.3",
@@ -115,6 +116,7 @@
     "test": "standard && node ./bin/test.js",
     "test-browser": "zuul -- test/*.js test/browser/*.js",
     "test-browser-local": "zuul --local -- test/*.js test/browser/*.js",
+    "test-browser-headless": "zuul --electron -- test/*.js test/browser/*.js",
     "test-node": "tape test/*.js test/node/*.js"
   }
 }

--- a/test/browser/basic.js
+++ b/test/browser/basic.js
@@ -13,84 +13,89 @@ function verifyImage (t, err, elem) {
   elem.remove()
 }
 
-test('image append w/ query selector', function (t) {
-  t.plan(6)
+// The image append/render tests don't work in electron, so skip them
+// TODO get these working
+// logic taken from https://github.com/atom/electron/issues/2288#issuecomment-123147993
+if (!(global && global.process && global.process.versions && global.process.versions.electron)) {
+  test('image append w/ query selector', function (t) {
+    t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+    var client = new WebTorrent({ dht: false, tracker: false })
 
-  client.on('error', function (err) { t.fail(err) })
-  client.on('warning', function (err) { t.fail(err) })
+    client.on('error', function (err) { t.fail(err) })
+    client.on('warning', function (err) { t.fail(err) })
 
-  client.seed(img, function (torrent) {
-    torrent.files[0].appendTo('body', function (err, elem) {
-      verifyImage(t, err, elem)
-      client.destroy(function (err) {
-        t.error(err, 'client destroyed')
+    client.seed(img, function (torrent) {
+      torrent.files[0].appendTo('body', function (err, elem) {
+        verifyImage(t, err, elem)
+        client.destroy(function (err) {
+          t.error(err, 'client destroyed')
+        })
       })
     })
   })
-})
 
-test('image append w/ element', function (t) {
-  t.plan(6)
+  test('image append w/ element', function (t) {
+    t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+    var client = new WebTorrent({ dht: false, tracker: false })
 
-  client.on('error', function (err) { t.fail(err) })
-  client.on('warning', function (err) { t.fail(err) })
+    client.on('error', function (err) { t.fail(err) })
+    client.on('warning', function (err) { t.fail(err) })
 
-  client.seed(img, function (torrent) {
-    torrent.files[0].appendTo(document.body, function (err, elem) {
-      verifyImage(t, err, elem)
-      client.destroy(function (err) {
-        t.error(err, 'client destroyed')
+    client.seed(img, function (torrent) {
+      torrent.files[0].appendTo(document.body, function (err, elem) {
+        verifyImage(t, err, elem)
+        client.destroy(function (err) {
+          t.error(err, 'client destroyed')
+        })
       })
     })
   })
-})
 
-test('image render w/ query selector', function (t) {
-  t.plan(6)
+  test('image render w/ query selector', function (t) {
+    t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+    var client = new WebTorrent({ dht: false, tracker: false })
 
-  client.on('error', function (err) { t.fail(err) })
-  client.on('warning', function (err) { t.fail(err) })
+    client.on('error', function (err) { t.fail(err) })
+    client.on('warning', function (err) { t.fail(err) })
 
-  var tag = document.createElement('img')
-  tag.className = 'tag'
-  document.body.appendChild(tag)
+    var tag = document.createElement('img')
+    tag.className = 'tag'
+    document.body.appendChild(tag)
 
-  client.seed(img, function (torrent) {
-    torrent.files[0].renderTo('img.tag', function (err, elem) {
-      verifyImage(t, err, elem)
-      client.destroy(function (err) {
-        t.error(err, 'client destroyed')
+    client.seed(img, function (torrent) {
+      torrent.files[0].renderTo('img.tag', function (err, elem) {
+        verifyImage(t, err, elem)
+        client.destroy(function (err) {
+          t.error(err, 'client destroyed')
+        })
       })
     })
   })
-})
 
-test('image render w/ element', function (t) {
-  t.plan(6)
+  test('image render w/ element', function (t) {
+    t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+    var client = new WebTorrent({ dht: false, tracker: false })
 
-  client.on('error', function (err) { t.fail(err) })
-  client.on('warning', function (err) { t.fail(err) })
+    client.on('error', function (err) { t.fail(err) })
+    client.on('warning', function (err) { t.fail(err) })
 
-  var tag = document.createElement('img')
-  document.body.appendChild(tag)
+    var tag = document.createElement('img')
+    document.body.appendChild(tag)
 
-  client.seed(img, function (torrent) {
-    torrent.files[0].renderTo(tag, function (err, elem) {
-      verifyImage(t, err, elem)
-      client.destroy(function (err) {
-        t.error(err, 'client destroyed')
+    client.seed(img, function (torrent) {
+      torrent.files[0].renderTo(tag, function (err, elem) {
+        verifyImage(t, err, elem)
+        client.destroy(function (err) {
+          t.error(err, 'client destroyed')
+        })
       })
     })
   })
-})
+}
 
 test('WebTorrent.WEBRTC_SUPPORT', function (t) {
   t.plan(2)


### PR DESCRIPTION
This makes the automated testing applied to pull requests a little more comprehensive. A couple caveats:

* This doesn't work on AppVeyor
* Most of the browser-specific tests are skipped

I'm hoping both of these can be resolved later, but this seems like a worthwhile change regardless. Here are example builds from my personal repo: [Travis](https://travis-ci.org/josephfrazier/webtorrent/builds/107940116), [AppVeyor](https://ci.appveyor.com/project/josephfrazier/webtorrent/build/1.0.10)