### PR TITLE
Don't cache node_modules in AppVeyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,6 @@ environment:
   - nodejs_version: "4"
   - nodejs_version: "0.12"
 
-# http://www.appveyor.com/docs/build-cache
-cache:
-  - node_modules
-
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js


### PR DESCRIPTION
See the discussion at
https://github.com/feross/webtorrent/pull/602#issuecomment-181987938

> I prefer not to cache the node_modules folder on CI since I want to
> catch bugs that exist in the latest published packages, i.e.  what a
> user will experience when running npm install webtorrent for the first
> time.