### PR TITLE
Fix syntax of magnet URI test

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "bittorrent-tracker": "^7.0.0",
     "brfs": "^1.2.0",
     "browserify": "^13.0.0",
+    "concat-stream": "^1.5.1",
     "cross-spawn-async": "^2.0.0",
     "finalhandler": "^0.4.0",
     "run-series": "^1.0.2",

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,5 +1,3 @@
-/* global Blob */
-
 var test = require('tape')
 var Readable = require('readable-stream').Readable
 var WebTorrent = require('../')
@@ -13,7 +11,7 @@ test('client.seed: stream', function (t) {
   var tracker = new Tracker()
   var seeder, client
   tracker.listen(function () {
-    announce.push('http://localhost:'+tracker.http.address().port)
+    announce.push('http://localhost:' + tracker.http.address().port)
     seeder = new WebTorrent({ dht: false })
     client = new WebTorrent({ dht: false })
 
@@ -25,7 +23,7 @@ test('client.seed: stream', function (t) {
     seed()
   })
   tracker.on('start', function () {
-    console.log('START', argument)
+    console.log('START', arguments)
   })
 
   t.once('end', function () {
@@ -34,7 +32,7 @@ test('client.seed: stream', function (t) {
     tracker.close()
   })
 
-  var stream = new Readable
+  var stream = new Readable()
   stream._read = function () {}
   stream.push('HELLO WORLD\n')
   stream.push(null)


### PR DESCRIPTION
This brings https://github.com/feross/webtorrent/commit/83226a40445d0a6987f15a7e010758ab8bc8dc0a up to `standard` (see the [failing test](https://travis-ci.org/feross/webtorrent/jobs/108154403#L916))