### PR TITLE
Wrap addrToIPPort in try/catch

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -463,7 +463,13 @@ Torrent.prototype.addPeer = function (peer) {
   if (self.client.blocked) {
     var addr = typeof peer === 'string' ? peer : peer.remoteAddress
 
-    if (addr && self.client.blocked.contains(addrToIPPort(addr)[0])) {
+    var parts
+    if (addr) {
+      try {
+        parts = addrToIPPort(addr)
+      } catch (e) { return false }
+    }
+    if (addr && self.client.blocked.contains(parts[0])) {
       self.numBlockedPeers += 1
       self.emit('blockedPeer', peer)
       return false


### PR DESCRIPTION
It was throwing an error when addr was not parsable, causing webtorrent to die.
See related: https://github.com/feross/bittorrent-swarm/pull/31.