### PR TITLE
Lower max requests of webseeds to real value

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1127,7 +1127,7 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   if (self.bitfield.get(index)) return false
 
   var maxOutstandingRequests = getPipelineLength(wire, PIPELINE_MAX_DURATION)
-  if (isWebSeed && maxOutstandingRequests > 2) maxOutstandingRequests -= 2; // A webseed will handle it's real max requests
+  if (isWebSeed && maxOutstandingRequests > 2) maxOutstandingRequests -= 2 // A webseed will handle it's real max requests
   if (numRequests >= maxOutstandingRequests) return false
   // var endGame = (wire.requests.length === 0 && self.store.numMissing < 30)
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1127,6 +1127,7 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   if (self.bitfield.get(index)) return false
 
   var maxOutstandingRequests = getPipelineLength(wire, PIPELINE_MAX_DURATION)
+  if (isWebSeed && maxOutstandingRequests > 2) maxOutstandingRequests -= 2; // A webseed will handle it's real max requests
   if (numRequests >= maxOutstandingRequests) return false
   // var endGame = (wire.requests.length === 0 && self.store.numMissing < 30)
 


### PR DESCRIPTION
`getPipelineLength` adds 2 extra more requests possible to each wire. See [L1303-L1305](https://github.com/feross/webtorrent/blob/master/lib/torrent.js#L1303-L1305)

In the case of a webseed, if it already has speed, let the webseed handle its real max requests.

This is merely a temporary attempt to make webseeds more stable and don't let them timeout

#650 is still on the works.