### PR TITLE
Limit the number of simultaneous connections per web seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ If `opts` is specified, then the default options (shown below) will be overridde
   announce: [],              // Torrent trackers to use (added to list in .torrent or magnet uri)
   getAnnounceOpts: function, // Custom callback to allow sending extra parameters to the tracker
   path: String,              // Folder to download files to (default=`/tmp/webtorrent/`)
-  store: Function            // Custom chunk store (must follow [abstract-chunk-store](https://www.npmjs.com/package/abstract-chunk-store) API),
+  store: Function,            // Custom chunk store (must follow [abstract-chunk-store](https://www.npmjs.com/package/abstract-chunk-store) API)
   maxWebConns: Number        // Max number of simultaneous connections per web seed
 }
 ```

--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ If `opts` is specified, then the default options (shown below) will be overridde
   announce: [],              // Torrent trackers to use (added to list in .torrent or magnet uri)
   getAnnounceOpts: function, // Custom callback to allow sending extra parameters to the tracker
   path: String,              // Folder to download files to (default=`/tmp/webtorrent/`)
-  store: Function            // Custom chunk store (must follow [abstract-chunk-store](https://www.npmjs.com/package/abstract-chunk-store) API)
+  store: Function            // Custom chunk store (must follow [abstract-chunk-store](https://www.npmjs.com/package/abstract-chunk-store) API),
+  maxWebConns: Number        // Max number of simultaneous connections per web seed
 }
 ```
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -76,6 +76,8 @@ function Torrent (torrentId, client, opts) {
 
   this.strategy = opts.strategy || 'sequential'
 
+  this.maxWebConns = opts.maxWebConns
+
   this._rechokeNumSlots = (opts.uploads === false || opts.uploads === 0)
     ? 0
     : (+opts.uploads || 10)
@@ -1127,7 +1129,11 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   if (self.bitfield.get(index)) return false
 
   var maxOutstandingRequests = getPipelineLength(wire, PIPELINE_MAX_DURATION)
-  if (isWebSeed && maxOutstandingRequests > 2) maxOutstandingRequests -= 2 // A webseed will handle it's real max requests
+  if (isWebSeed) {
+    // A webseed will handle it's real max requests
+    if (maxOutstandingRequests > 2) maxOutstandingRequests -= 2
+    if (self.maxWebConns) maxOutstandingRequests = Math.min(maxOutstandingRequests, self.maxWebConns)
+  }
   if (numRequests >= maxOutstandingRequests) return false
   // var endGame = (wire.requests.length === 0 && self.store.numMissing < 30)
 


### PR DESCRIPTION
PR #663 limits the amount of connections in case of low bandwidth web seed
But in case of per IP connection limits like 

nginx's [limit_conn addr](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html)
[Wowza](https://www.wowza.com/products/streaming-engine/documentation)
[Nimble](http://blog.wmspanel.com/p/nimble-streamer-configuration.html)

this prevents connection rejections (HTTP 50x) and consecuently web seed been discarded as discussed in #650