### PR TITLE
add default webrtc trackers when there is webrtc support 

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -30,6 +30,8 @@ var Swarm = require('bittorrent-swarm')
 var uniq = require('uniq')
 var ut_metadata = require('ut_metadata')
 var ut_pex = require('ut_pex') // browser exclude
+var Peer = require('simple-peer')
+var createTorrent = require('create-torrent')
 
 var File = require('./file')
 var RarityMap = require('./rarity-map')
@@ -49,6 +51,16 @@ var RECHOKE_OPTIMISTIC_DURATION = 2 // 30 seconds
 var TMP = typeof pathExists.sync === 'function'
   ? path.join(pathExists.sync('/tmp') ? '/tmp' : os.tmpDir(), 'webtorrent')
   : '/tmp/webtorrent'
+
+if (Peer.WEBRTC_SUPPORT && !global.WEBTORRENT_ANNOUNCE) {
+  global.WEBTORRENT_ANNOUNCE = createTorrent.announceList
+    .map(function (arr) {
+      return arr[0]
+    })
+    .filter(function (url) {
+      return url.indexOf('wss://') === 0 || url.indexOf('ws://') === 0
+    })
+}
 
 inherits(Torrent, EventEmitter)
 

--- a/test/client-add.js
+++ b/test/client-add.js
@@ -16,7 +16,7 @@ test('client.add: magnet uri, utf-8 string', function (t) {
 
   torrent.on('infoHash', function () {
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split('&tr')[0], fixtures.leaves.magnetURI)
 
     client.remove(fixtures.leaves.magnetURI, function (err) { t.error(err, 'torrent destroyed') })
     t.equal(client.torrents.length, 0)
@@ -38,7 +38,7 @@ test('client.add: torrent file, buffer', function (t) {
 
   torrent.on('infoHash', function () {
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split('&tr')[0], fixtures.leaves.magnetURI)
 
     client.remove(fixtures.leaves.torrent, function (err) { t.error(err, 'torrent destroyed') })
     t.equal(client.torrents.length, 0)
@@ -104,7 +104,7 @@ test('client.add: parsed torrent, from `parse-torrent`', function (t) {
 
   torrent.on('infoHash', function () {
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split('&tr')[0], fixtures.leaves.magnetURI)
 
     client.remove(fixtures.leaves.parsedTorrent, function (err) { t.error(err, 'torrent destroyed') })
     t.equal(client.torrents.length, 0)

--- a/test/client-add.js
+++ b/test/client-add.js
@@ -16,7 +16,7 @@ test('client.add: magnet uri, utf-8 string', function (t) {
 
   torrent.on('infoHash', function () {
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI, fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
 
     client.remove(fixtures.leaves.magnetURI, function (err) { t.error(err, 'torrent destroyed') })
     t.equal(client.torrents.length, 0)
@@ -38,7 +38,7 @@ test('client.add: torrent file, buffer', function (t) {
 
   torrent.on('infoHash', function () {
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI, fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
 
     client.remove(fixtures.leaves.torrent, function (err) { t.error(err, 'torrent destroyed') })
     t.equal(client.torrents.length, 0)
@@ -104,7 +104,7 @@ test('client.add: parsed torrent, from `parse-torrent`', function (t) {
 
   torrent.on('infoHash', function () {
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI, fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
 
     client.remove(fixtures.leaves.parsedTorrent, function (err) { t.error(err, 'torrent destroyed') })
     t.equal(client.torrents.length, 0)

--- a/test/client-seed.js
+++ b/test/client-seed.js
@@ -17,7 +17,7 @@ test('client.seed: torrent file (Buffer)', function (t) {
   }, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI, fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
 
     client.remove(torrent, function (err) { t.error(err, 'torrent removed') })
     t.equal(client.torrents.length, 0)
@@ -40,7 +40,7 @@ test('client.seed: torrent file (Buffer), set name on buffer', function (t) {
   client.seed(buf, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI, fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
 
     client.remove(torrent, function (err) { t.error(err, 'torrent removed') })
     t.equal(client.torrents.length, 0)
@@ -64,7 +64,7 @@ test('client.seed: torrent file (Blob)', function (t) {
   }, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI, fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
 
     client.remove(torrent, function (err) { t.error(err, 'torrent removed') })
     t.equal(client.torrents.length, 0)

--- a/test/client-seed.js
+++ b/test/client-seed.js
@@ -17,7 +17,7 @@ test('client.seed: torrent file (Buffer)', function (t) {
   }, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split('&tr')[0], fixtures.leaves.magnetURI)
 
     client.remove(torrent, function (err) { t.error(err, 'torrent removed') })
     t.equal(client.torrents.length, 0)
@@ -40,7 +40,7 @@ test('client.seed: torrent file (Buffer), set name on buffer', function (t) {
   client.seed(buf, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split('&tr')[0], fixtures.leaves.magnetURI)
 
     client.remove(torrent, function (err) { t.error(err, 'torrent removed') })
     t.equal(client.torrents.length, 0)
@@ -64,7 +64,7 @@ test('client.seed: torrent file (Blob)', function (t) {
   }, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
-    t.equal(torrent.magnetURI.split("&tr")[0], fixtures.leaves.magnetURI)
+    t.equal(torrent.magnetURI.split('&tr')[0], fixtures.leaves.magnetURI)
 
     client.remove(torrent, function (err) { t.error(err, 'torrent removed') })
     t.equal(client.torrents.length, 0)


### PR DESCRIPTION
and global.WEBTORRENT_ANNOUNCE is not defined (fix #672)
