### PR TITLE
provide the torrent instance in the opts.store() options

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,6 +63,13 @@ If you want access to the torrent object immediately in order to listen to event
 metadata is fetched from the network, then use the return value of `client.add`. If you
 just want the file data, then use `ontorrent` or the 'torrent' event.
 
+If you provide `opts.store`, it will be called as
+`opts.store(chunkLength, storeOpts)` with:
+
+* `storeOpts.length` - size of all the files in the torrent
+* `storeOpts.files` - an array of torrent file objects
+* `storeOpts.torrent` - the torrent instance being stored
+
 ## `client.seed(input, [opts], [function onseed (torrent) {}])`
 
 Start seeding a new torrent.

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -344,6 +344,7 @@ Torrent.prototype._onMetadata = function (metadata) {
 
   self.store = new ImmediateChunkStore(
     new self._store(self.pieceLength, {
+      torrent: self,
       files: self.files.map(function (file) {
         return {
           path: path.join(self.path, file.path),


### PR DESCRIPTION
Currently, `opts.store()` is called with the chunkLength, the `opts.length` containing the size of the torrent file, and the `opts.files` which is an array of the files in the torrent. This patch adds the torrent instance itself to the chunk store options, so that you can procedurally generate a path based on for example the infoHash for the storage of each torrent.