### PR TITLE
Only add new ut_pex peers when we're not seeding

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -654,6 +654,8 @@ Torrent.prototype._onWire = function (wire, addr) {
     wire.use(ut_pex())
 
     wire.ut_pex.on('peer', function (peer) {
+      // Only add potential new peers when we're not seeding
+      if (self.done) return
       self._debug('ut_pex: got peer: %s (from %s)', peer, addr)
       self.addPeer(peer)
     })
@@ -669,7 +671,7 @@ Torrent.prototype._onWire = function (wire, addr) {
     })
   }
 
-  // Hook to allow user-defined `bittorrent-protocol extensions
+  // Hook to allow user-defined `bittorrent-protocol` extensions
   // More info: https://github.com/feross/bittorrent-protocol#extension-api
   self.emit('wire', wire, addr)
 


### PR DESCRIPTION
Otherwise, we get into a loop of connect, get pex messages, disconnect
because they don't have pieces we need (because we're seeding), try
connecting to the pex peers, etc. etc.