### PR TITLE
On wire close, stop ut_pex sending interval

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -669,6 +669,11 @@ Torrent.prototype._onWire = function (wire, addr) {
         self.swarm.removePeer(peer)
       }
     })
+
+    wire.once('close', function () {
+      // Stop sending updates to remote peer
+      wire.ut_pex.reset()
+    })
   }
 
   // Hook to allow user-defined `bittorrent-protocol` extensions
@@ -724,7 +729,7 @@ Torrent.prototype._onWireWithMetadata = function (wire) {
     wire.unchoke()
   })
 
-  wire.on('close', function () {
+  wire.once('close', function () {
     clearTimeout(timeoutId)
   })
 


### PR DESCRIPTION
This was a source of interval leaks