### PR TITLE
Base web seed pipeline length on piece length

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -932,9 +932,9 @@ Torrent.prototype._updateWire = function (wire) {
   if (wire.peerChoking) return
   if (!wire.downloaded) return validateWire()
 
-  var minOutstandingRequests = getPipelineLength(wire, PIPELINE_MIN_DURATION)
+  var minOutstandingRequests = getBlockPipelineLength(wire, PIPELINE_MIN_DURATION)
   if (wire.requests.length >= minOutstandingRequests) return
-  var maxOutstandingRequests = getPipelineLength(wire, PIPELINE_MAX_DURATION)
+  var maxOutstandingRequests = getBlockPipelineLength(wire, PIPELINE_MAX_DURATION)
 
   trySelectWire(false) || trySelectWire(true)
 
@@ -1187,7 +1187,7 @@ Torrent.prototype._hotswap = function (wire, index) {
     var req = minWire.requests[i]
     if (req.piece !== index) continue
 
-    self.pieces[index].cancel((req.offset / Piece.BLOCK_SIZE) | 0)
+    self.pieces[index].cancel((req.offset / Piece.BLOCK_LENGTH) | 0)
   }
 
   self.emit('hotswap', minWire, wire, index)
@@ -1204,12 +1204,13 @@ Torrent.prototype._request = function (wire, index, hotswap) {
 
   if (self.bitfield.get(index)) return false
 
-  var maxOutstandingRequests = getPipelineLength(wire, PIPELINE_MAX_DURATION)
-  if (isWebSeed) {
-    // A webseed will handle it's real max requests
-    if (maxOutstandingRequests > 2) maxOutstandingRequests -= 2
-    if (self.maxWebConns) maxOutstandingRequests = Math.min(maxOutstandingRequests, self.maxWebConns)
-  }
+  var maxOutstandingRequests = isWebSeed
+    ? Math.min(
+        getPiecePipelineLength(wire, PIPELINE_MAX_DURATION, self.pieceLength),
+        self.maxWebConns
+      )
+    : getBlockPipelineLength(wire, PIPELINE_MAX_DURATION)
+
   if (numRequests >= maxOutstandingRequests) return false
   // var endGame = (wire.requests.length === 0 && self.store.numMissing < 30)
 
@@ -1383,8 +1384,12 @@ Torrent.prototype._debug = function () {
   debug.apply(null, args)
 }
 
-function getPipelineLength (wire, duration) {
-  return Math.ceil(2 + duration * wire.downloadSpeed() / Piece.BLOCK_LENGTH)
+function getBlockPipelineLength (wire, duration) {
+  return 2 + Math.ceil(duration * wire.downloadSpeed() / Piece.BLOCK_LENGTH)
+}
+
+function getPiecePipelineLength (wire, duration, pieceLength) {
+  return 1 + Math.ceil(duration * wire.downloadSpeed() / pieceLength)
 }
 
 /**


### PR DESCRIPTION
Before this, the web seed pipeline length was based on the block size,
just like it is for wire connections, which are block-based.

This meant that we were massively over-estimating the number of http
requests to make to the web seed servers.

Now we use the piece length, since each web seed request is a piece
length in size.