### PR TITLE
Add 'noPeers' event to torrents

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -413,6 +413,10 @@ See the `bittorrent-protocol`
 [extension api docs](https://github.com/feross/bittorrent-protocol#extension-api) for more
 information on how to define a protocol extension.
 
+## `torrent.on('noPeers', function (announceType) {})`
+
+Emitted whenever a DHT or tracker announce occurs, but no peers have been found.  `announceType` is either `'tracker'` or `'dht'` depending on which announce occurred to trigger this event.  Note that if you're attempting to discover peers from both a tracker and a DHT, you'll see this event separately for each.
+
 # File API
 
 ## `file.name`

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -333,12 +333,12 @@ Torrent.prototype._onListening = function () {
 
   function onTrackerAnnounce () {
     self.emit('trackerAnnounce')
-    if (self.swarm.numPeers === 0) self.emit('noPeers', 'tracker')
+    if (self.numPeers === 0) self.emit('noPeers', 'tracker')
   }
 
   function onDHTAnnounce () {
     self.emit('dhtAnnounce')
-    if (self.swarm.numPeers === 0) self.emit('noPeers', 'dht')
+    if (self.numPeers === 0) self.emit('noPeers', 'dht')
   }
 
   function onWarning (err) {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -333,10 +333,12 @@ Torrent.prototype._onListening = function () {
 
   function onTrackerAnnounce () {
     self.emit('trackerAnnounce')
+    if (self.swarm.numPeers === 0) self.emit('noPeers', 'tracker')
   }
 
   function onDHTAnnounce () {
     self.emit('dhtAnnounce')
+    if (self.swarm.numPeers === 0) self.emit('noPeers', 'dht')
   }
 
   function onWarning (err) {

--- a/test/node/download-dht-torrent.js
+++ b/test/node/download-dht-torrent.js
@@ -53,10 +53,17 @@ test('Download using DHT (via .torrent file)', function (t) {
         maybeDone(null)
       })
 
+      torrent.on('noPeers', function (announceType) {
+        t.equal(announceType, 'dht', 'noPeers event seen with correct announceType')
+        noPeersFound = true
+        maybeDone(null)
+      })
+
       var announced = false
       var loaded = false
+      var noPeersFound = false
       function maybeDone (err) {
-        if ((announced && loaded) || err) cb(err, client1)
+        if ((announced && loaded && noPeersFound) || err) cb(err, client1)
       }
     },
 

--- a/test/node/download-dht-torrent.js
+++ b/test/node/download-dht-torrent.js
@@ -6,7 +6,7 @@ var test = require('tape')
 var WebTorrent = require('../../')
 
 test('Download using DHT (via .torrent file)', function (t) {
-  t.plan(9)
+  t.plan(10)
 
   var dhtServer = new DHT({ bootstrap: false })
 

--- a/test/node/download-tracker-magnet.js
+++ b/test/node/download-tracker-magnet.js
@@ -15,7 +15,7 @@ test('Download using HTTP tracker (via magnet uri)', function (t) {
 })
 
 function magnetDownloadTest (t, serverType) {
-  t.plan(9)
+  t.plan(10)
 
   var tracker = new TrackerServer(
     serverType === 'udp' ? { http: false, ws: false } : { udp: false, ws: false }
@@ -58,6 +58,10 @@ function magnetDownloadTest (t, serverType) {
         var names = [
           'Leaves of Grass by Walt Whitman.epub'
         ]
+
+        torrent.on('noPeers', function (announceType) {
+          t.equal(announceType, 'tracker', 'noPeers event seen with correct announceType')
+        })
 
         t.deepEqual(torrent.files.map(function (file) { return file.name }), names)
 


### PR DESCRIPTION
The 'noPeers' event is emitted after tracker or DHT announce events when there are still no peers in the swarm.