### PR TITLE
On duplicate torrent add, don't emit 'infoHash'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # WebTorrent Version History
 
+## UNRELEASED
+
+- When a duplicate torrent is added, don't emit the 'infoHash' event after 'error'. The 'error' event should be the last event.
+
 ## v0.93.1 - 2016-05-08
 
 - Remove `path-exists` dependency.

--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ WebTorrent.prototype.add = function (torrentId, opts, ontorrent) {
   var torrent = new Torrent(torrentId, self, opts)
   self.torrents.push(torrent)
 
-  torrent.once('infoHash', onInfoHash)
+  torrent.once('_infoHash', onInfoHash)
   torrent.once('ready', onReady)
   torrent.once('close', onClose)
 
@@ -262,7 +262,7 @@ WebTorrent.prototype.add = function (torrentId, opts, ontorrent) {
   }
 
   function onClose () {
-    torrent.removeListener('infoHash', onInfoHash)
+    torrent.removeListener('_infoHash', onInfoHash)
     torrent.removeListener('ready', onReady)
     torrent.removeListener('close', onClose)
   }

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -253,8 +253,14 @@ Torrent.prototype._onParsedTorrent = function (parsedTorrent) {
   }, RECHOKE_INTERVAL)
   if (self._rechokeIntervalId.unref) self._rechokeIntervalId.unref()
 
+  // Private 'infoHash' event allows client.add to check for duplicate torrents and
+  // destroy them before the normal 'infoHash' event is emitted. Prevents user
+  // applications from needing to deal with duplicate 'infoHash' events.
+  self.emit('_infoHash', self.infoHash)
+  if (self.destroyed) return
+
   self.emit('infoHash', self.infoHash)
-  if (self.destroyed) return // user might destroy torrent in `infoHash` event handler
+  if (self.destroyed) return // user might destroy torrent in event handler
 
   if (self.client.listening) {
     self._onListening()


### PR DESCRIPTION
Private '_infoHash' event allows client.add to check for duplicate
torrents and destroy them before the normal 'infoHash' event is
emitted. Prevents user applications from needing to deal with duplicate
'infoHash' events.