### PR TITLE
Implement exact source (xs) for magnet URIs

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -12,6 +12,7 @@ var extend = require('xtend')
 var extendMutable = require('xtend/mutable')
 var fs = require('fs')
 var FSChunkStore = require('fs-chunk-store') // browser: `memory-chunk-store`
+var get = require('simple-get')
 var ImmediateChunkStore = require('immediate-chunk-store')
 var inherits = require('inherits')
 var MultiStream = require('multistream')
@@ -113,6 +114,7 @@ function Torrent (torrentId, client, opts) {
 
   // for cleanup
   this._servers = []
+  this._xsRequest = null
 
   // TODO: remove this and expose a hook instead
   // optimization: don't recheck every file if it hasn't changed
@@ -269,6 +271,38 @@ Torrent.prototype._onParsedTorrent = function (parsedTorrent) {
       self._onListening()
     })
   }
+
+  if (parsedTorrent.xs && !self.info) {
+    // TODO: Could try multiple in parallel here
+    var src = parsedTorrent.xs instanceof Array ? parsedTorrent.xs[0] : parsedTorrent.xs
+    var isHTTP = src.substring(0, 7) === 'http://' || src.substring(0, 8) === 'https://'
+
+    if (isHTTP) {
+      var opts = {
+        url: src,
+        method: 'GET',
+        headers: {
+          'user-agent': 'WebTorrent (http://webtorrent.io)'
+        }
+      }
+      this._xsRequest = get.concat(opts, function (err, res, torrent) {
+        if (err || res.statusCode !== 200 || !torrent.length) return
+
+        var parsedTorrent
+        try {
+          parsedTorrent = parseTorrent(torrent)
+        } catch (err) {}
+
+        if (parsedTorrent) {
+          if (parsedTorrent.infoHash !== self.infoHash) {
+            return
+          }
+
+          self._onMetadata(parsedTorrent)
+        }
+      })
+    }
+  }
 }
 
 Torrent.prototype._processParsedTorrent = function (parsedTorrent) {
@@ -371,6 +405,10 @@ Torrent.prototype._onListening = function () {
  */
 Torrent.prototype._onMetadata = function (metadata) {
   var self = this
+  if (self._xsRequest) {
+    self._xsRequest.abort()
+    self._xsRequest = null
+  }
   if (self.metadata || self.destroyed) return
   self._debug('got metadata')
 
@@ -553,6 +591,9 @@ Torrent.prototype._destroy = function (err, cb) {
   self.destroyed = true
   self._debug('destroy')
 
+  if (self._xsRequest) {
+    self._xsRequest.abort()
+  }
   self.client._remove(self)
 
   clearInterval(self._rechokeIntervalId)
@@ -612,6 +653,7 @@ Torrent.prototype._destroy = function (err, cb) {
   self._rarityMap = null
   self._peers = null
   self._servers = null
+  self._xsRequest = null
 }
 
 Torrent.prototype.addPeer = function (peer) {

--- a/test/node/download-metadata.js
+++ b/test/node/download-metadata.js
@@ -1,0 +1,65 @@
+var fixtures = require('webtorrent-fixtures')
+var http = require('http')
+var test = require('tape')
+var WebTorrent = require('../../')
+
+function createServer (data, cb) {
+  var server = http.createServer(function (req, res) {
+    res.end(data)
+  }).listen(function () {
+    var address = server.address()
+    if (address.family === 'IPv6') {
+      address.address = '[' + address.address + ']'
+    }
+    var url = 'http://' + address.address + ':' + address.port + '/'
+    cb(url, next)
+  })
+
+  function next () {
+    server.close()
+  }
+}
+
+test('Download metadata for magnet URI with xs parameter', function (t) {
+  t.plan(2)
+
+  var client = new WebTorrent({ dht: false, tracker: false })
+
+  createServer(fixtures.leaves.torrent, function (url, next) {
+    client.add(fixtures.leaves.magnetURI + '&xs=' + encodeURIComponent(url), function (torrent) {
+      t.equal(torrent.name, 'Leaves of Grass by Walt Whitman.epub')
+
+      client.destroy(function (err) { t.error(err, 'client destroyed') })
+      next()
+    })
+  })
+})
+
+test('Download metadata for magnet URI with xs parameter', function (t) {
+  t.plan(2)
+
+  var client = new WebTorrent({ dht: false, tracker: false })
+
+  createServer(fixtures.leaves.torrent, function (url, next) {
+    var encoded = encodeURIComponent(url)
+    var uri = fixtures.leaves.magnetURI + '&xs=' + encoded + '&xs=' + encoded + '2'
+
+    client.add(uri, function (torrent) {
+      t.equal(torrent.name, 'Leaves of Grass by Walt Whitman.epub')
+
+      client.destroy(function (err) { t.error(err, 'client destroyed') })
+      next()
+    })
+  })
+})
+
+test('Download metadata magnet URI with unsupported protocol in xs parameter', function (t) {
+  t.plan(2)
+
+  var client = new WebTorrent({ dht: false, tracker: false })
+  client.add(fixtures.leaves.magnetURI + '&xs=' + encodeURIComponent('invalidurl:example'))
+  setTimeout(function () {
+    t.ok(true, 'no crash')
+    client.destroy(function (err) { t.error(err, 'client destroyed') })
+  }, 100)
+})


### PR DESCRIPTION
Since I saw #714 stalled a bit, I wanted to check in if no one's working on this and started off with a minimal working prototype.

I know I still need to move the fixture over (also don't rely on webtorrent.io, but create a local server instead) to the other repo, but does this look okay / is anyone else working on this?