### PR TITLE
Fix exception in file.js

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -16,6 +16,7 @@ function File (torrent, file) {
   EventEmitter.call(this)
 
   this._torrent = torrent
+  this._destroyed = false
 
   this.name = file.name
   this.path = file.path
@@ -61,6 +62,7 @@ File.prototype.createReadStream = function (opts) {
     fileStream._notify()
   })
   eos(fileStream, function () {
+    if (self._destroyed) return
     if (!self._torrent.destroyed) {
       self._torrent.deselect(fileStream._startPiece, fileStream._endPiece, true)
     }
@@ -89,5 +91,6 @@ File.prototype.renderTo = function (elem, cb) {
 }
 
 File.prototype._destroy = function () {
+  this._destroyed = true
   this._torrent = null
 }


### PR DESCRIPTION
If file is destroyed and stream ends afterwards, then an exception is
thrown because self._torrent is undefined.