### PR TITLE
Use safe-buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = WebTorrent
 
+var Buffer = require('safe-buffer').Buffer
 var concat = require('simple-concat')
 var createTorrent = require('create-torrent')
 var debug = require('debug')('webtorrent')
@@ -59,9 +60,9 @@ function WebTorrent (opts) {
   } else if (Buffer.isBuffer(opts.peerId)) {
     self.peerId = opts.peerId.toString('hex')
   } else {
-    self.peerId = new Buffer(VERSION_PREFIX + hat(48))
+    self.peerId = Buffer.from(VERSION_PREFIX + hat(48))
   }
-  self.peerIdBuffer = new Buffer(self.peerId, 'hex')
+  self.peerIdBuffer = Buffer.from(self.peerId, 'hex')
 
   if (typeof opts.nodeId === 'string') {
     self.nodeId = opts.nodeId
@@ -70,7 +71,7 @@ function WebTorrent (opts) {
   } else {
     self.nodeId = hat(160)
   }
-  self.nodeIdBuffer = new Buffer(self.nodeId, 'hex')
+  self.nodeIdBuffer = Buffer.from(self.nodeId, 'hex')
 
   self.destroyed = false
   self.listening = false

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -1,6 +1,7 @@
 module.exports = WebConn
 
 var BitField = require('bitfield')
+var Buffer = require('safe-buffer').Buffer
 var debug = require('debug')('webtorrent:webconn')
 var get = require('simple-get')
 var inherits = require('inherits')
@@ -101,7 +102,12 @@ WebConn.prototype.httpRequest = function (pieceIndex, offset, length, cb) {
   // Send requests in parallel and wait for them all to come back
   var numRequestsSucceeded = 0
   var hasError = false
-  if (requests.length > 1) var ret = new Buffer(length)
+
+  var ret
+  if (requests.length > 1) {
+    ret = Buffer.alloc(length)
+  }
+
   requests.forEach(function (request) {
     var url = request.url
     var start = request.start
@@ -129,14 +135,17 @@ WebConn.prototype.httpRequest = function (pieceIndex, offset, length, cb) {
         return cb(new Error('Unexpected HTTP status code ' + res.statusCode))
       }
       debug('Got data of length %d', data.length)
+
       if (requests.length === 1) {
         // Common case: fetch piece in a single HTTP request, return directly
-        return cb(null, data)
-      }
-      // Rare case: reconstruct multiple HTTP requests across 2+ files into one piece buffer
-      data.copy(ret, request.fileOffsetInRange)
-      if (++numRequestsSucceeded === requests.length) {
-        cb(null, ret)
+        cb(null, data)
+      } else {
+        // Rare case: reconstruct multiple HTTP requests across 2+ files into one
+        // piece buffer
+        data.copy(ret, request.fileOffsetInRange)
+        if (++numRequestsSucceeded === requests.length) {
+          cb(null, ret)
+        }
       }
     })
   })

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "render-media": "^2.0.0",
     "run-parallel": "^1.0.0",
     "run-parallel-limit": "^1.0.2",
+    "safe-buffer": "^5.0.0",
     "simple-concat": "^1.0.0",
     "simple-get": "^2.0.0",
     "simple-peer": "^6.0.0",

--- a/test/browser/basic.js
+++ b/test/browser/basic.js
@@ -1,7 +1,8 @@
+var Buffer = require('safe-buffer').Buffer
 var test = require('tape')
 var WebTorrent = require('../../')
 
-var img = new Buffer('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64')
+var img = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64')
 img.name = 'img.png'
 
 function verifyImage (t, err, elem) {

--- a/test/client-add.js
+++ b/test/client-add.js
@@ -1,3 +1,4 @@
+var Buffer = require('safe-buffer').Buffer
 var extend = require('xtend')
 var fixtures = require('webtorrent-fixtures')
 var test = require('tape')
@@ -84,7 +85,7 @@ test('client.add: info hash, buffer', function (t) {
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
     t.ok(torrent.magnetURI.indexOf('magnet:?xt=urn:btih:' + fixtures.leaves.parsedTorrent.infoHash) === 0)
 
-    client.remove(new Buffer(fixtures.leaves.parsedTorrent.infoHash, 'hex'), function (err) { t.error(err, 'torrent destroyed') })
+    client.remove(Buffer.from(fixtures.leaves.parsedTorrent.infoHash, 'hex'), function (err) { t.error(err, 'torrent destroyed') })
     t.equal(client.torrents.length, 0)
 
     client.destroy(function (err) { t.error(err, 'client destroyed') })
@@ -204,5 +205,5 @@ test('client.add: invalid torrent id: short buffer', function (t) {
   })
   client.on('warning', function (err) { t.fail(err) })
 
-  client.add(new Buffer('abc'))
+  client.add(Buffer.from('abc'))
 })

--- a/test/client-destroy.js
+++ b/test/client-destroy.js
@@ -1,3 +1,4 @@
+var Buffer = require('safe-buffer').Buffer
 var fixtures = require('webtorrent-fixtures')
 var test = require('tape')
 var WebTorrent = require('../')
@@ -16,7 +17,7 @@ test('after client.destroy(), throw on client.add() or client.seed()', function 
     client.add('magnet:?xt=urn:btih:' + fixtures.leaves.parsedTorrent.infoHash)
   })
   t.throws(function () {
-    client.seed(new Buffer('sup'))
+    client.seed(Buffer.from('sup'))
   })
 })
 

--- a/test/client-seed.js
+++ b/test/client-seed.js
@@ -1,5 +1,6 @@
 /* global Blob */
 
+var Buffer = require('safe-buffer').Buffer
 var fixtures = require('webtorrent-fixtures')
 var test = require('tape')
 var WebTorrent = require('../')
@@ -34,7 +35,7 @@ test('client.seed: torrent file (Buffer), set name on buffer', function (t) {
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
 
-  var buf = new Buffer(fixtures.leaves.content)
+  var buf = Buffer.from(fixtures.leaves.content)
   buf.name = 'Leaves of Grass by Walt Whitman.epub'
 
   client.seed(buf, function (torrent) {

--- a/test/node/swarm-basic.js
+++ b/test/node/swarm-basic.js
@@ -1,11 +1,12 @@
+// var Buffer = require('safe-buffer').Buffer
 // var hat = require('hat')
 // var Swarm = require('../../lib/swarm')
 // var test = require('tape')
 
 // var infoHash = 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36'
 // var infoHash2 = 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa37'
-// var peerId = new Buffer('-WW0001-' + hat(48), 'utf8').toString('hex')
-// var peerId2 = new Buffer('-WW0001-' + hat(48), 'utf8').toString('hex')
+// var peerId = Buffer.from('-WW0001-' + hat(48), 'utf8').toString('hex')
+// var peerId2 = Buffer.from('-WW0001-' + hat(48), 'utf8').toString('hex')
 
 // test('two swarms listen on same port', function (t) {
 //   t.plan(2)

--- a/test/node/swarm-reconnect.js
+++ b/test/node/swarm-reconnect.js
@@ -1,10 +1,11 @@
+// var Buffer = require('safe-buffer').Buffer
 // var hat = require('hat')
 // var Swarm = require('../../lib/swarm')
 // var test = require('tape')
 
 // var infoHash = 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36'
-// var peerId1 = new Buffer('-WW0001-' + hat(48), 'utf8').toString('hex')
-// var peerId2 = new Buffer('-WW0001-' + hat(48), 'utf8').toString('hex')
+// var peerId1 = Buffer.from('-WW0001-' + hat(48), 'utf8').toString('hex')
+// var peerId2 = Buffer.from('-WW0001-' + hat(48), 'utf8').toString('hex')
 
 // test('reconnect when peer disconnects', function (t) {
 //   t.plan(10)

--- a/test/node/swarm-timeout.js
+++ b/test/node/swarm-timeout.js
@@ -1,10 +1,11 @@
+// var Buffer = require('safe-buffer').Buffer
 // var hat = require('hat')
 // var Swarm = require('../../lib/swarm')
 // var test = require('tape')
 
 // var infoHash = 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36'
-// var peerId1 = new Buffer('-WW0001-' + hat(48), 'utf8').toString('hex')
-// var peerId2 = new Buffer('-WW0001-' + hat(48), 'utf8').toString('hex')
+// var peerId1 = Buffer.from('-WW0001-' + hat(48), 'utf8').toString('hex')
+// var peerId2 = Buffer.from('-WW0001-' + hat(48), 'utf8').toString('hex')
 
 // test('timeout if no handshake in 25 seconds', function (t) {
 //   t.plan(4)

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -1,11 +1,12 @@
+// var Buffer = require('safe-buffer').Buffer
 // var hat = require('hat')
 // var Swarm = require('../lib/swarm')
 // var test = require('tape')
 
 // var infoHash = 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36'
 // var infoHash2 = 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa37'
-// var peerId = new Buffer('-WW0001-' + hat(48), 'utf8').toString('hex')
-// var peerId2 = new Buffer('-WW0001-' + hat(48), 'utf8').toString('hex')
+// var peerId = Buffer.from('-WW0001-' + hat(48), 'utf8').toString('hex')
+// var peerId2 = Buffer.from('-WW0001-' + hat(48), 'utf8').toString('hex')
 
 // test('create swarm, check invariants', function (t) {
 //   var swarm = new Swarm(infoHash, peerId)


### PR DESCRIPTION
Use the new Buffer APIs from Node v6 for added security. For example,
`Buffer.from()` will throw if passed a number, unlike `Buffer()` which
allocated UNINITIALIZED memory in that case.

Use the `safe-buffer` package for compatibility with previous versions of
Node.js, including v4.x, v0.12, and v0.10.

https://github.com/feross/safe-buffer