### PR TITLE
Null check pendingConns

### DIFF
--- a/lib/tcp-pool.js
+++ b/lib/tcp-pool.js
@@ -119,7 +119,7 @@ TCPPool.prototype._onConnection = function (conn) {
   function cleanupPending () {
     conn.removeListener('close', cleanupPending)
     wire.removeListener('handshake', onHandshake)
-    arrayRemove(self._pendingConns, self._pendingConns.indexOf(conn))
+    if(self._pendingConns) arrayRemove(self._pendingConns, self._pendingConns.indexOf(conn))
   }
 }
 


### PR DESCRIPTION
Prevent arrayRemove if the pool is already destroyed. Fixes possible error `TypeError: Cannot read property 'indexOf' of null`