### PR TITLE
Use memory chunk store for unit tests

### DIFF
--- a/test/node/download-dht-magnet.js
+++ b/test/node/download-dht-magnet.js
@@ -1,6 +1,7 @@
 var DHT = require('bittorrent-dht/server')
 var fixtures = require('webtorrent-fixtures')
 var fs = require('fs')
+var MemoryChunkStore = require('memory-chunk-store')
 var networkAddress = require('network-address')
 var series = require('run-series')
 var test = require('tape')
@@ -34,7 +35,7 @@ test('Download using DHT (via magnet uri)', function (t) {
       client1.on('error', function (err) { t.fail(err) })
       client1.on('warning', function (err) { t.fail(err) })
 
-      var torrent = client1.add(fixtures.leaves.parsedTorrent)
+      var torrent = client1.add(fixtures.leaves.parsedTorrent, {store: MemoryChunkStore})
 
       torrent.on('dhtAnnounce', function () {
         t.pass('finished dht announce')
@@ -89,7 +90,7 @@ test('Download using DHT (via magnet uri)', function (t) {
         })
       })
 
-      client2.add(fixtures.leaves.magnetURI)
+      client2.add(fixtures.leaves.magnetURI, {store: MemoryChunkStore})
 
       var gotBuffer = false
       var gotDone = false

--- a/test/node/download-dht-torrent.js
+++ b/test/node/download-dht-torrent.js
@@ -1,6 +1,7 @@
 var DHT = require('bittorrent-dht/server')
 var fixtures = require('webtorrent-fixtures')
 var fs = require('fs')
+var MemoryChunkStore = require('memory-chunk-store')
 var series = require('run-series')
 var test = require('tape')
 var WebTorrent = require('../../')
@@ -33,7 +34,7 @@ test('Download using DHT (via .torrent file)', function (t) {
       client1.on('error', function (err) { t.fail(err) })
       client1.on('warning', function (err) { t.fail(err) })
 
-      var torrent = client1.add(fixtures.leaves.parsedTorrent)
+      var torrent = client1.add(fixtures.leaves.parsedTorrent, {store: MemoryChunkStore})
 
       torrent.on('ready', function () {
         // torrent metadata has been fetched -- sanity check it
@@ -99,7 +100,7 @@ test('Download using DHT (via .torrent file)', function (t) {
         }
       })
 
-      client2.add(fixtures.leaves.parsedTorrent)
+      client2.add(fixtures.leaves.parsedTorrent, {store: MemoryChunkStore})
     }
   ], function (err) {
     t.error(err)

--- a/test/node/download-metadata.js
+++ b/test/node/download-metadata.js
@@ -1,5 +1,6 @@
 var fixtures = require('webtorrent-fixtures')
 var http = require('http')
+var MemoryChunkStore = require('memory-chunk-store')
 var test = require('tape')
 var WebTorrent = require('../../')
 
@@ -32,7 +33,7 @@ test('Download metadata for magnet URI with xs parameter', function (t) {
 
   createServer(fixtures.leaves.torrent, function (url, server) {
     var encodedUrl = encodeURIComponent(url)
-    client.add(fixtures.leaves.magnetURI + '&xs=' + encodedUrl, function (torrent) {
+    client.add(fixtures.leaves.magnetURI + '&xs=' + encodedUrl, {store: MemoryChunkStore}, function (torrent) {
       t.equal(torrent.files[0].name, 'Leaves of Grass by Walt Whitman.epub')
       client.destroy(function (err) { t.error(err, 'client destroyed') })
       server.close(function () { t.pass('server closed') })
@@ -56,7 +57,7 @@ test('Download metadata for magnet URI with 2 xs parameters', function (t) {
 
       var uri = fixtures.leaves.magnetURI + '&xs=' + encodedUrl1 + '&xs=' + encodedUrl2
 
-      client.add(uri, function (torrent) {
+      client.add(uri, {store: MemoryChunkStore}, function (torrent) {
         t.equal(torrent.files[0].name, 'Leaves of Grass by Walt Whitman.epub')
         client.destroy(function (err) { t.error(err, 'client destroyed') })
         server1.close(function () { t.pass('server closed') })
@@ -79,7 +80,7 @@ test('Download metadata for magnet URI with 2 xs parameters, with 1 invalid prot
     var encodedUrl2 = encodeURIComponent(url)
     var uri = fixtures.leaves.magnetURI + '&xs=' + encodedUrl1 + '&xs=' + encodedUrl2
 
-    client.add(uri, function (torrent) {
+    client.add(uri, {store: MemoryChunkStore}, function (torrent) {
       t.equal(torrent.files[0].name, 'Leaves of Grass by Walt Whitman.epub')
       client.destroy(function (err) { t.error(err, 'client destroyed') })
       server.close(function () { t.pass('server closed') })
@@ -100,7 +101,7 @@ test('Download metadata for magnet URI with 2 xs parameters, with 1 404 URL', fu
     var encodedUrl2 = encodeURIComponent(url)
     var uri = fixtures.leaves.magnetURI + '&xs=' + encodedUrl1 + '&xs=' + encodedUrl2
 
-    client.add(uri, function (torrent) {
+    client.add(uri, {store: MemoryChunkStore}, function (torrent) {
       t.equal(torrent.files[0].name, 'Leaves of Grass by Walt Whitman.epub')
       client.destroy(function (err) { t.error(err, 'client destroyed') })
       server.close(function () { t.pass('server closed') })
@@ -116,7 +117,7 @@ test('Download metadata magnet URI with unsupported protocol in xs parameter', f
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
 
-  client.add(fixtures.leaves.magnetURI + '&xs=' + encodeURIComponent('invalidurl:example'))
+  client.add(fixtures.leaves.magnetURI + '&xs=' + encodeURIComponent('invalidurl:example'), {store: MemoryChunkStore})
 
   setTimeout(function () {
     // no crash by now

--- a/test/node/download-private-dht.js
+++ b/test/node/download-private-dht.js
@@ -1,5 +1,6 @@
 var DHT = require('bittorrent-dht/server')
 var fixtures = require('webtorrent-fixtures')
+var MemoryChunkStore = require('memory-chunk-store')
 var series = require('run-series')
 var test = require('tape')
 var WebTorrent = require('../../')
@@ -28,7 +29,7 @@ test('private torrent should not use DHT', function (t) {
       client.on('error', function (err) { t.fail(err) })
       client.on('warning', function (err) { t.fail(err) })
 
-      var torrent = client.add(fixtures.bunny.parsedTorrent)
+      var torrent = client.add(fixtures.bunny.parsedTorrent, {store: MemoryChunkStore})
 
       torrent.on('dhtAnnounce', function () {
         t.fail('client announced to dht')
@@ -76,7 +77,7 @@ test('public torrent should use DHT', function (t) {
       client.on('error', function (err) { t.fail(err) })
       client.on('warning', function (err) { t.fail(err) })
 
-      var torrent = client.add(fixtures.leaves.parsedTorrent)
+      var torrent = client.add(fixtures.leaves.parsedTorrent, {store: MemoryChunkStore})
 
       torrent.on('dhtAnnounce', function () {
         t.pass('client announced to dht')

--- a/test/node/download-tracker-magnet.js
+++ b/test/node/download-tracker-magnet.js
@@ -1,6 +1,7 @@
 var extend = require('xtend')
 var fixtures = require('webtorrent-fixtures')
 var fs = require('fs')
+var MemoryChunkStore = require('memory-chunk-store')
 var series = require('run-series')
 var test = require('tape')
 var TrackerServer = require('bittorrent-tracker/server')
@@ -15,7 +16,7 @@ test('Download using HTTP tracker (via magnet uri)', function (t) {
 })
 
 function magnetDownloadTest (t, serverType) {
-  t.plan(10)
+  t.plan(11)
 
   var tracker = new TrackerServer(
     serverType === 'udp' ? { http: false, ws: false } : { udp: false, ws: false }
@@ -70,7 +71,7 @@ function magnetDownloadTest (t, serverType) {
         })
       })
 
-      client1.add(parsedTorrent)
+      client1.add(parsedTorrent, {store: MemoryChunkStore})
     },
 
     function (cb) {
@@ -102,7 +103,7 @@ function magnetDownloadTest (t, serverType) {
         }
       })
 
-      client2.add(magnetURI)
+      client2.add(magnetURI, {store: MemoryChunkStore})
     }
 
   ], function (err) {

--- a/test/node/download-tracker-torrent.js
+++ b/test/node/download-tracker-torrent.js
@@ -1,6 +1,7 @@
 var extend = require('xtend')
 var fixtures = require('webtorrent-fixtures')
 var fs = require('fs')
+var MemoryChunkStore = require('memory-chunk-store')
 var series = require('run-series')
 var test = require('tape')
 var TrackerServer = require('bittorrent-tracker/server')
@@ -65,7 +66,7 @@ function torrentDownloadTest (t, serverType) {
         torrent.load(fs.createReadStream(fixtures.leaves.contentPath), cb)
       })
 
-      client1.add(parsedTorrent)
+      client1.add(parsedTorrent, {store: MemoryChunkStore})
     },
 
     function (cb) {
@@ -73,7 +74,7 @@ function torrentDownloadTest (t, serverType) {
       client2.on('error', function (err) { t.fail(err) })
       client2.on('warning', function (err) { t.fail(err) })
 
-      client2.add(parsedTorrent)
+      client2.add(parsedTorrent, {store: MemoryChunkStore})
 
       client2.on('torrent', function (torrent) {
         torrent.files.forEach(function (file) {

--- a/test/node/download-webseed-magnet.js
+++ b/test/node/download-webseed-magnet.js
@@ -2,6 +2,7 @@ var finalhandler = require('finalhandler')
 var fixtures = require('webtorrent-fixtures')
 var http = require('http')
 var path = require('path')
+var MemoryChunkStore = require('memory-chunk-store')
 var series = require('run-series')
 var serveStatic = require('serve-static')
 var test = require('tape')
@@ -10,7 +11,7 @@ var WebTorrent = require('../../')
 test('Download using webseed (via magnet uri)', function (t) {
   t.plan(9)
 
-  var serve = serveStatic(path.join(__dirname, 'content'))
+  var serve = serveStatic(path.dirname(fixtures.leaves.contentPath))
   var httpServer = http.createServer(function (req, res) {
     var done = finalhandler(req, res)
     serve(req, res, done)
@@ -51,7 +52,7 @@ test('Download using webseed (via magnet uri)', function (t) {
         maybeDone()
       })
 
-      var torrent = client1.add(fixtures.leaves.parsedTorrent)
+      var torrent = client1.add(fixtures.leaves.parsedTorrent, {store: MemoryChunkStore})
 
       torrent.on('infoHash', function () {
         gotListening = true
@@ -91,7 +92,7 @@ test('Download using webseed (via magnet uri)', function (t) {
         }
       })
 
-      var torrent = client2.add(magnetURI)
+      var torrent = client2.add(magnetURI, {store: MemoryChunkStore})
 
       torrent.on('infoHash', function () {
         torrent.addPeer('127.0.0.1:' + client1.address().port)

--- a/test/node/download-webseed-torrent.js
+++ b/test/node/download-webseed-torrent.js
@@ -2,6 +2,7 @@ var extend = require('xtend')
 var finalhandler = require('finalhandler')
 var fixtures = require('webtorrent-fixtures')
 var http = require('http')
+var MemoryChunkStore = require('memory-chunk-store')
 var path = require('path')
 var series = require('run-series')
 var serveStatic = require('serve-static')
@@ -15,7 +16,7 @@ test('Download using webseed (via .torrent file)', function (t) {
 
   var httpServer = http.createServer(function (req, res) {
     var done = finalhandler(req, res)
-    serveStatic(path.join(__dirname, 'content'))(req, res, done)
+    serveStatic(path.dirname(fixtures.leaves.contentPath))(req, res, done)
   })
   var client
 
@@ -59,7 +60,7 @@ test('Download using webseed (via .torrent file)', function (t) {
         }
       })
 
-      client.add(parsedTorrent)
+      client.add(parsedTorrent, {store: MemoryChunkStore})
     }
   ], function (err) {
     t.error(err)

--- a/test/node/seed-while-download.js
+++ b/test/node/seed-while-download.js
@@ -1,6 +1,7 @@
 var DHT = require('bittorrent-dht/server')
 var fixtures = require('webtorrent-fixtures')
 var fs = require('fs')
+var MemoryChunkStore = require('memory-chunk-store')
 var series = require('run-series')
 var test = require('tape')
 var WebTorrent = require('../../')
@@ -29,7 +30,7 @@ test('Seed and download a file at the same time', function (t) {
       client1.on('error', function (err) { t.fail(err) })
       client1.on('warning', function (err) { t.fail(err) })
 
-      var torrent = client1.add(fixtures.leaves.torrent)
+      var torrent = client1.add(fixtures.leaves.torrent, {store: MemoryChunkStore})
 
       torrent.on('dhtAnnounce', function () {
         t.pass('client1 finished dht announce')
@@ -60,7 +61,7 @@ test('Seed and download a file at the same time', function (t) {
       client2.on('error', function (err) { t.fail(err) })
       client2.on('warning', function (err) { t.fail(err) })
 
-      var torrent = client2.add(fixtures.alice.torrent)
+      var torrent = client2.add(fixtures.alice.torrent, {store: MemoryChunkStore})
 
       torrent.on('dhtAnnounce', function () {
         t.pass('client2 finished dht announce')
@@ -82,7 +83,7 @@ test('Seed and download a file at the same time', function (t) {
     },
 
     function (cb) {
-      client1.add(fixtures.alice.magnetURI)
+      client1.add(fixtures.alice.magnetURI, {store: MemoryChunkStore})
 
       client1.on('torrent', function (torrent) {
         torrent.files[0].getBuffer(function (err, buf) {
@@ -99,7 +100,7 @@ test('Seed and download a file at the same time', function (t) {
         })
       })
 
-      client2.add(fixtures.leaves.magnetURI)
+      client2.add(fixtures.leaves.magnetURI, {store: MemoryChunkStore})
 
       client2.on('torrent', function (torrent) {
         torrent.files[0].getBuffer(function (err, buf) {


### PR DESCRIPTION
The webseed tests were not using fixtures module but passed anyway because the fs store was already populated with the data of a previous test.

This PR uses memory chunk store to ensure the store is empty before running a test.