### PR TITLE
Cross-origin URL redirection workaround

### DIFF
--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -124,12 +124,7 @@ WebConn.prototype.httpRequest = function (pieceIndex, offset, length, cb) {
         range: 'bytes=' + start + '-' + end
       }
     }
-    get.concat(opts, function (err, res, data) {
-      if (hasError) return
-      if (err) {
-        hasError = true
-        return cb(err)
-      }
+    function onResponse (res, data) {
       if (res.statusCode < 200 || res.statusCode >= 300) {
         hasError = true
         return cb(new Error('Unexpected HTTP status code ' + res.statusCode))
@@ -147,6 +142,51 @@ WebConn.prototype.httpRequest = function (pieceIndex, offset, length, cb) {
           cb(null, ret)
         }
       }
+    }
+    get.concat(opts, function (err, res, data) {
+      if (hasError) return
+      if (err) {
+        // Browsers allow HTTP redirects for simple cross-origin
+        // requests but not for requests that require preflight.
+        // Use a simple request to unravel any redirects and get the
+        // final URL.  Retry the original request with the new URL if
+        // it's different.
+        //
+        // This test is imperfect but it's simple and good for common
+        // cases.  It catches all cross-origin cases but matches a few
+        // same-origin cases too.
+        if (typeof window === 'undefined' || url.startsWith(window.location.origin + '/')) {
+          hasError = true
+          return cb(err)
+        }
+
+        return get.head(url, function (errHead, res) {
+          if (hasError) return
+          if (errHead) {
+            hasError = true
+            return cb(errHead)
+          }
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            hasError = true
+            return cb(new Error('Unexpected HTTP status code ' + res.statusCode))
+          }
+          if (res.url === url) {
+            hasError = true
+            return cb(err)
+          }
+
+          opts.url = res.url
+          get.concat(opts, function (err, res, data) {
+            if (hasError) return
+            if (err) {
+              hasError = true
+              return cb(err)
+            }
+            onResponse(res, data)
+          })
+        })
+      }
+      onResponse(res, data)
     })
   })
 }


### PR DESCRIPTION
Browsers allow HTTP redirects for simple cross-origin requests but not for requests that require preflight.
Because they set the Range header, this includes all web seed requests (if they're cross-origin).
So currently, web seeds can be cross-origin or they can make redirects, but not both at the same time.
What do you think of the following workaround for this?

If a request fails, maybe it's because the web seed sent a redirect and the browser objected, so try a simple request.
Make a simple request to unwind any redirects and get the final URL. (I used a HEAD request for this.)
If the final URL doesn't match the original URL, retry our original request with the new URL.
I make a feeble attempt to check that this is a cross-origin request.
It catches all cross-origin cases, but matches a few same-origin cases too. I figure that's okay in the interest of simplicity, since the check is merely an optimization anyway.