### PR TITLE
Option to disable BEP19 web seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # WebTorrent Version History
 
+## v0.97.0 - 2016-09-17
+
+- Option to disable web seeds (BEP19)
+
 ## v0.95.2 - 2016-06-22
 
 - HEAD requests  to HTTP server should not send entire body

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,11 +51,12 @@ If `opts` is specified, then the default options (shown below) will be overridde
 
 ```js
 {
-  dht: Boolean|Object,     // Enable DHT (default=true), or options object for DHT
   maxConns: Number,        // Max number of connections per torrent (default=55)
   nodeId: String|Buffer,   // DHT protocol node ID (default=randomly generated)
   peerId: String|Buffer,   // Wire protocol peer ID (default=randomly generated)
-  tracker: Boolean|Object  // Enable trackers (default=true), or options object for Tracker
+  tracker: Boolean|Object, // Enable trackers (default=true), or options object for Tracker
+  dht: Boolean|Object,     // Enable DHT (default=true), or options object for DHT
+  webSeeds: Boolean        // Enable BEP19 web seeds (default=true)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -139,6 +139,9 @@ function WebTorrent (opts) {
     self.dht = false
   }
 
+  // Enable or disable BEP19 (Web Seeds). Enabled by default:
+  self.enableWebSeeds = opts.webSeeds !== false
+
   if (typeof loadIPSet === 'function' && opts.blocklist != null) {
     loadIPSet(opts.blocklist, {
       headers: {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -471,9 +471,11 @@ Torrent.prototype._onMetadata = function (metadata) {
   self.metadata = self.torrentFile
 
   // add web seed urls (BEP19)
-  self.urlList.forEach(function (url) {
-    self.addWebSeed(url)
-  })
+  if (self.client.enableWebSeeds) {
+    self.urlList.forEach(function (url) {
+      self.addWebSeed(url)
+    })
+  }
 
   // start off selecting the entire torrent with low priority
   if (self.pieces.length !== 0) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webtorrent",
   "description": "Streaming torrent client",
-  "version": "0.96.5",
+  "version": "0.97.0",
   "author": {
     "name": "WebTorrent, LLC",
     "email": "feross@webtorrent.io",

--- a/test/node/download-webseed-torrent.js
+++ b/test/node/download-webseed-torrent.js
@@ -9,8 +9,12 @@ var serveStatic = require('serve-static')
 var test = require('tape')
 var WebTorrent = require('../../')
 
+// it should be fast to download a small torrent over local HTTP
+var WEB_SEED_TIMEOUT_MS = 500
+
 test('Download using webseed (via .torrent file)', function (t) {
   t.plan(6)
+  t.timeoutAfter(WEB_SEED_TIMEOUT_MS)
 
   var parsedTorrent = extend(fixtures.leaves.parsedTorrent)
 
@@ -69,6 +73,49 @@ test('Download using webseed (via .torrent file)', function (t) {
     })
     httpServer.close(function () {
       t.pass('http server closed')
+    })
+  })
+})
+
+test('Disable webseeds', function (t) {
+  var parsedTorrent = extend(fixtures.leaves.parsedTorrent)
+
+  var httpServer = http.createServer(function (req, res) {
+    t.fail('webseed http server should not get any requests')
+  })
+  var client
+
+  httpServer.on('error', function (err) { t.fail(err) })
+
+  series([
+    function (cb) {
+      httpServer.listen(cb)
+    },
+
+    function (cb) {
+      parsedTorrent.urlList = [
+        'http://localhost:' + httpServer.address().port + '/' + fixtures.leaves.parsedTorrent.name
+      ]
+
+      client = new WebTorrent({ dht: false, tracker: false, webSeeds: false })
+
+      client.on('error', function (err) { t.fail(err) })
+      client.on('warning', function (err) { t.fail(err) })
+
+      client.add(parsedTorrent, {store: MemoryChunkStore})
+
+      // The test above ensures that we can download the whole torrent over webseeds within a
+      // short time. Here, we wait the same amount of time and make sure no HTTP requests happen.
+      setTimeout(cb, WEB_SEED_TIMEOUT_MS)
+    }
+  ], function (err) {
+    t.error(err)
+    client.destroy(function (err) {
+      t.error(err, 'client destroyed')
+    })
+    httpServer.close(function () {
+      t.pass('http server closed')
+      t.end()
     })
   })
 })


### PR DESCRIPTION
* For completeness. We have options to enable/disable WebRTC, the regular BitTorrent tracker client, and the DHT client. This lets us also enable/disable web seeds. 
* Useful for WebTorrent Desktop integration testing. See https://github.com/electron/electron/issues/7212
