### PR TITLE
Seed: allow announce field with trackers disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,7 +303,6 @@ WebTorrent.prototype.seed = function (input, opts, onseed) {
   // When seeding from fs path, initialize store from that path to avoid a copy
   if (typeof input === 'string') opts.path = path.dirname(input)
   if (!opts.createdBy) opts.createdBy = 'WebTorrent/' + VERSION_STR
-  if (!self.tracker) opts.announce = []
 
   var torrent = self.add(null, opts, onTorrent)
   var streams

--- a/test/client-seed.js
+++ b/test/client-seed.js
@@ -14,7 +14,8 @@ test('client.seed: torrent file (Buffer)', function (t) {
   client.on('warning', function (err) { t.fail(err) })
 
   client.seed(fixtures.leaves.content, {
-    name: 'Leaves of Grass by Walt Whitman.epub'
+    name: 'Leaves of Grass by Walt Whitman.epub',
+    announce: []
   }, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
@@ -38,7 +39,7 @@ test('client.seed: torrent file (Buffer), set name on buffer', function (t) {
   var buf = Buffer.from(fixtures.leaves.content)
   buf.name = 'Leaves of Grass by Walt Whitman.epub'
 
-  client.seed(buf, function (torrent) {
+  client.seed(buf, {announce: []}, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
     t.equal(torrent.magnetURI, fixtures.leaves.magnetURI)
@@ -61,7 +62,8 @@ test('client.seed: torrent file (Blob)', function (t) {
   client.on('warning', function (err) { t.fail(err) })
 
   client.seed(new Blob([ fixtures.leaves.content ]), {
-    name: 'Leaves of Grass by Walt Whitman.epub'
+    name: 'Leaves of Grass by Walt Whitman.epub',
+    announce: []
   }, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -77,7 +77,8 @@ test('client.seed: filesystem path to file, string', function (t) {
   client.on('warning', function (err) { t.fail(err) })
 
   client.seed(fixtures.leaves.contentPath, {
-    name: 'Leaves of Grass by Walt Whitman.epub'
+    name: 'Leaves of Grass by Walt Whitman.epub',
+    announce: []
   }, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
@@ -98,7 +99,7 @@ test('client.seed: filesystem path to folder with one file, string', function (t
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
 
-  client.seed(fixtures.folder.contentPath, function (torrent) {
+  client.seed(fixtures.folder.contentPath, {announce: false}, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.folder.parsedTorrent.infoHash)
     t.equal(torrent.magnetURI, fixtures.folder.magnetURI)
@@ -118,7 +119,7 @@ test('client.seed: filesystem path to folder with multiple files, string', funct
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
 
-  client.seed(fixtures.numbers.contentPath, function (torrent) {
+  client.seed(fixtures.numbers.contentPath, {announce: false}, function (torrent) {
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.numbers.parsedTorrent.infoHash)
     t.equal(torrent.magnetURI, fixtures.numbers.magnetURI)


### PR DESCRIPTION
Creating a WebTorrent client with the `{tracker: false}` option means it doesn't talk to trackers -- only (potentially) the DHT and web seeds.

However, creating a torrent using `.seed()` should still work normally, and the resulting torrent's `announce` field should be the same as it would normally be.