### PR TITLE
Add more peer ID entropy

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function WebTorrent (opts) {
   } else if (Buffer.isBuffer(opts.peerId)) {
     self.peerId = opts.peerId.toString('hex')
   } else {
-    self.peerId = Buffer.from(VERSION_PREFIX + randombytes(6).toString('hex')).toString('hex')
+    self.peerId = Buffer.from(VERSION_PREFIX + randombytes(9).toString('base64')).toString('hex')
   }
   self.peerIdBuffer = Buffer.from(self.peerId, 'hex')
 


### PR DESCRIPTION
This still keeps the peer ID printable as ascii, while adding lots more
entropy