### PR TITLE
Don't run Electron tests on Travis

### DIFF
--- a/bin/test.js
+++ b/bin/test.js
@@ -6,11 +6,11 @@ var runSauceLabs = !process.env.CI ||
   (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY)
 
 npmRun('test-node', function () {
-  npmRun('test-browser-headless', function () {
-    if (runSauceLabs) {
-      npmRun('test-browser')
-    }
-  })
+  if (runSauceLabs) {
+    npmRun('test-browser')
+  } else {
+    npmRun('test-browser-headless')
+  }
 })
 
 function npmRun (scriptName, onSuccess) {


### PR DESCRIPTION
This is a workaround for https://github.com/feross/webtorrent/issues/945

Note that pull requests from other repos will still run the Electron
tests (and remind us that it's broken), but at least master will be
green again.