### PR TITLE
Don't send 'completed' event to tracker on client.seed

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1532,7 +1532,7 @@ Torrent.prototype._request = function (wire, index, hotswap) {
           wire.have(index)
         })
 
-        self._checkDone(onDone)
+        if (self._checkDone()) self.discovery.complete()
       } else {
         self.pieces[index] = new Piece(piece.length)
         self.emit('warning', new Error('Piece ' + index + ' failed verification'))
@@ -1541,10 +1541,6 @@ Torrent.prototype._request = function (wire, index, hotswap) {
     })
   })
 
-  function onDone () {
-    self.discovery.complete()
-  }
-
   function onUpdateTick () {
     process.nextTick(function () { self._update() })
   }
@@ -1552,10 +1548,9 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   return true
 }
 
-Torrent.prototype._checkDone = function (cb) {
+Torrent.prototype._checkDone = function () {
   var self = this
   if (self.destroyed) return
-  if (!cb) cb = noop
 
   // are any new files done?
   self.files.forEach(function (file) {
@@ -1584,11 +1579,11 @@ Torrent.prototype._checkDone = function (cb) {
   if (!self.done && done) {
     self.done = true
     self._debug('torrent done: ' + self.infoHash)
-    cb(null)
     self.emit('done')
   }
-
   self._gcSelections()
+
+  return done
 }
 
 Torrent.prototype.load = function (streams, cb) {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1532,7 +1532,7 @@ Torrent.prototype._request = function (wire, index, hotswap) {
           wire.have(index)
         })
 
-        self._checkDone()
+        self._checkDone(onDone)
       } else {
         self.pieces[index] = new Piece(piece.length)
         self.emit('warning', new Error('Piece ' + index + ' failed verification'))
@@ -1541,6 +1541,10 @@ Torrent.prototype._request = function (wire, index, hotswap) {
     })
   })
 
+  function onDone () {
+    self.discovery.complete()
+  }
+
   function onUpdateTick () {
     process.nextTick(function () { self._update() })
   }
@@ -1548,9 +1552,10 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   return true
 }
 
-Torrent.prototype._checkDone = function () {
+Torrent.prototype._checkDone = function (cb) {
   var self = this
   if (self.destroyed) return
+  if (!cb) cb = noop
 
   // are any new files done?
   self.files.forEach(function (file) {
@@ -1579,7 +1584,7 @@ Torrent.prototype._checkDone = function () {
   if (!self.done && done) {
     self.done = true
     self._debug('torrent done: ' + self.infoHash)
-    self.discovery.complete()
+    cb(null)
     self.emit('done')
   }
 


### PR DESCRIPTION
Follow-on to [bittorrent-tracker/#185](https://github.com/feross/bittorrent-tracker/pull/185)

Completed event now only emits when a previously started torrent download completes