### PR TITLE
Emit more warnings

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -387,7 +387,7 @@ Torrent.prototype._getMetadataFromServer = function () {
 
   function getMetadataFromURL (url, cb) {
     if (url.indexOf('http://') !== 0 && url.indexOf('https://') !== 0) {
-      self._debug('skipping non-http xs param: %s', url)
+      self.emit('warning', new Error('skipping non-http xs param: ' + url))
       return cb(null)
     }
 
@@ -402,7 +402,7 @@ Torrent.prototype._getMetadataFromServer = function () {
     try {
       req = get.concat(opts, onResponse)
     } catch (err) {
-      self._debug('skipping invalid url xs param: %s', url)
+      self.emit('warning', new Error('skipping invalid url xs param: ' + url))
       return cb(null)
     }
 
@@ -413,11 +413,11 @@ Torrent.prototype._getMetadataFromServer = function () {
       if (self.metadata) return cb(null)
 
       if (err) {
-        self._debug('http error from xs param: %s', url)
+        self.emit('warning', new Error('http error from xs param: ' + url))
         return cb(null)
       }
       if (res.statusCode !== 200) {
-        self._debug('non-200 status code %s from xs param: %s', res.statusCode, url)
+        self.emit('warning', new Error('non-200 status code ' + res.statusCode + ' from xs param: ' + url))
         return cb(null)
       }
 
@@ -427,12 +427,12 @@ Torrent.prototype._getMetadataFromServer = function () {
       } catch (err) {}
 
       if (!parsedTorrent) {
-        self._debug('got invalid torrent file from xs param: %s', url)
+        self.emit('warning', new Error('got invalid torrent file from xs param: ' + url))
         return cb(null)
       }
 
       if (parsedTorrent.infoHash !== self.infoHash) {
-        self._debug('got torrent file with incorrect info hash from xs param: %s', url)
+        self.emit('warning', new Error('got torrent file with incorrect info hash from xs param: ' + url))
         return cb(null)
       }
 
@@ -795,13 +795,13 @@ Torrent.prototype.addWebSeed = function (url) {
   if (this.destroyed) throw new Error('torrent is destroyed')
 
   if (!/^https?:\/\/.+/.test(url)) {
-    this._debug('ignoring invalid web seed %s', url)
+    this.emit('warning', new Error('ignoring invalid web seed: ' + url))
     this.emit('invalidPeer', url)
     return
   }
 
   if (this._peers[url]) {
-    this._debug('ignoring duplicate web seed %s', url)
+    this.emit('warning', new Error('ignoring duplicate web seed: ' + url))
     this.emit('invalidPeer', url)
     return
   }


### PR DESCRIPTION
Convert some debug statements that could be useful for an API user
(either because they want to show to the user, or to react to the
warning in some way)

Fixes https://github.com/feross/webtorrent/issues/960