### PR TITLE
Change os.tmpDir() to os.tmpdir()

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -58,7 +58,7 @@ var TMP
 try {
   TMP = path.join(fs.statSync('/tmp') && '/tmp', 'webtorrent')
 } catch (err) {
-  TMP = path.join(typeof os.tmpDir === 'function' ? os.tmpDir() : '/', 'webtorrent')
+  TMP = path.join(typeof os.tmpdir === 'function' ? os.tmpdir() : '/', 'webtorrent')
 }
 
 inherits(Torrent, EventEmitter)


### PR DESCRIPTION
Just a small change to fix a deprecation warning.