### PR TITLE
Updating electron-prebuilt to 1.4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "brfs": "^1.4.3",
     "browserify": "^14.0.0",
     "cross-spawn": "^5.0.1",
-    "electron-prebuilt": "^0.37.8",
+    "electron-prebuilt": "^1.4.13",
     "finalhandler": "^0.5.0",
     "network-address": "^1.1.0",
     "run-series": "^1.1.4",


### PR DESCRIPTION

Please update [electron-prebuilt](https://npmjs.org/package/electron-prebuilt) to version 1.4.13.

If this passes your tests you can merge it in.  If not please use this branch for changes.

