### PR TITLE
Use bogota to run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "bittorrent-tracker": "^8.0.7",
+    "bogota": "^2.0.1",
     "brfs": "^1.4.3",
     "browserify": "^14.0.0",
     "cross-spawn": "^5.0.1",
@@ -119,7 +120,7 @@
     "test-browser": "zuul -- test/*.js test/browser/*.js",
     "test-browser-headless": "zuul --electron -- test/*.js test/browser/*.js",
     "test-browser-local": "zuul --local -- test/*.js test/browser/*.js",
-    "test-node": "tape test/*.js test/node/*.js",
+    "test-node": "bogota test/*.js test/node/*.js",
     "update-authors": "./bin/update-authors.sh"
   }
 }


### PR DESCRIPTION
I created a tape test runner that runs tests concurrently. Source: https://github.com/DiegoRBaquero/bogota

## Time results using gtime in my Mac:

**tape**:
```sh
# gtime tape test/node/*.js
1.73user 0.25system 0:04.50elapsed
1.72user 0.24system 0:04.47elapsed
1.77user 0.26system 0:04.54elapsed
1.84user 0.25system 0:04.62elapsed
1.65user 0.21system 0:04.26elapsed
1.70user 0.20system 0:04.28elapsed
1.64user 0.21system 0:04.24elapsed
1.69user 0.30system 0:04.61elapsed
```

**bogota**:
```sh
# gtime bogota test/node/*.js
5.06user 0.65system 0:03.36elapsed
5.26user 0.63system 0:02.70elapsed
5.13user 0.63system 0:03.80elapsed
5.29user 0.63system 0:02.90elapsed
4.98user 0.57system 0:03.28elapsed
4.66user 0.54system 0:03.46elapsed
4.92user 0.55system 0:03.14elapsed
4.66user 0.55system 0:03.13elapsed
```