### PR TITLE
Fix detection of seeding peers

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1046,10 +1046,10 @@ Torrent.prototype._onWireWithMetadata = function (wire) {
     }
   }
 
-  var i = 0
+  var i
   function updateSeedStatus () {
-    if (wire.peerPieces.length !== self.pieces.length) return
-    for (; i < self.pieces.length; ++i) {
+    if (wire.peerPieces.buffer.length !== self.bitfield.buffer.length) return
+    for (i = 0; i < self.pieces.length; ++i) {
       if (!wire.peerPieces.get(i)) return
     }
     wire.isSeeder = true


### PR DESCRIPTION
`wire.peerPieces.length` is always undefined, which meant the `updateSeedStatus` function was always returning early, and peers were never being detected as seeds.