### PR TITLE
add filename to path

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -107,7 +107,7 @@ function Server (torrent, opts) {
         return serveIndexPage()
       }
 
-      var index = Number(pathname.slice(1))
+      var index = Number(pathname.split('/')[1])
       if (Number.isNaN(index) || index >= torrent.files.length) {
         return serve404Page()
       }
@@ -121,7 +121,7 @@ function Server (torrent, opts) {
       res.setHeader('Content-Type', 'text/html')
 
       var listHtml = torrent.files.map(function (file, i) {
-        return '<li><a download="' + file.name + '" href="/' + i + '">' + file.path + '</a> ' +
+        return '<li><a download="' + file.name + '" href="/' + i + '/' + file.name + '">' + file.path + '</a> ' +
           '(' + file.length + ' bytes)</li>'
       }).join('<br>')
 


### PR DESCRIPTION
This allows you to add the filename to the path with produces more readable and understandable URLs. It doesn't actually do anything with or require the additional URL params so it shouldn't break any existing deployments.

Current URL:
`localhost:3000/0`

New URL:
`localhost:3000/0/FILE_NAME.mp4`